### PR TITLE
feat: adicionando orçamento do time de estrutura

### DIFF
--- a/docs/relatorio/editaveis/07_orcamento.tex
+++ b/docs/relatorio/editaveis/07_orcamento.tex
@@ -47,4 +47,55 @@ Impressão 3D & Montagem & 4,00   & 2,00 & Ciclano                   \\ \hline
 \end{center}
 \end{table}
 
+\section{Orçamento - Estrutura}
+
+\noindent O orçamento da área de Estrutura contempla tanto os materiais e insumos necessários para a construção do labirinto quanto os custos associados à fabricação do chassi do robô. Para o labirinto, foram considerados os gastos com MDF para a base e para as paredes, tintas para acabamento, além de parafusos, buchas e pinos cavilha para fixação e montagem. Para o chassi, foi estimado um consumo aproximado de 50 g de filamento, com base em um valor de R\$ 150,00 por quilograma, resultando em R\$ 7,50 de material. Além disso, foi previsto um valor de R\$ 40,00 para o serviço de impressão 3D, considerando uso do equipamento, preparação do arquivo, tempo de impressão, energia, desgaste da máquina e mão de obra, bem como R\$ 10,00 destinados aos parafusos de fixação. Dessa forma, o orçamento total da área de Estrutura foi estimado em R\$ 167,50.
+
+\begin{table}[htpb]
+\begin{center}
+\caption{Orçamento geral atualizado da Estrutura.}
+\begin{tabular}{|c|c|c|}
+\hline
+\textbf{Geral}          & \textbf{Previsto (R\$)} & \textbf{Realizado (R\$)} \\ \hline
+Matéria-prima           & 107,50                  & ---                      \\ \hline
+Fixadores               & 18,00                   & ---                      \\ \hline
+Acabamento              & 52,00                   & ---                      \\ \hline
+Montagem                & 40,00                   & ---                      \\ \hline
+\textbf{Total}          & \textbf{167,50}         & \textbf{---}             \\ \hline
+\end{tabular}
+\end{center}
+\end{table}
+
+\noindent A divisão adotada neste orçamento considera como matéria-prima o MDF do labirinto e o PLA do chassi. Os custos com fixadores incluem parafusos, buchas, pinos cavilha e parafusos do chassi. O acabamento corresponde às tintas utilizadas no labirinto, enquanto a montagem contempla o serviço de impressão 3D.
+
+\begin{table}[htpb]
+\begin{center}
+\caption{Orçamento por aquisição atualizado da Estrutura.}
+\begin{tabular}{|p{7cm}|p{3.3cm}|c|c|c|}
+\hline
+\textbf{Item ou serviço} & \textbf{Tipo} & \textbf{Previsto (R\$)} & \textbf{Realizado (R\$)} & \textbf{Responsável} \\ \hline
+MDF para base do labirinto          & Matéria-prima & 26,00  & --- & Estrutura \\ \hline
+MDF para paredes do labirinto       & Matéria-prima & 12,00  & --- & Estrutura \\ \hline
+Tintas para acabamento do labirinto & Acabamento    & 52,00  & --- & Estrutura \\ \hline
+Parafusos e buchas do labirinto     & Fixadores     & 12,00  & --- & Estrutura \\ \hline
+Pinos cavilha do labirinto          & Fixadores     & 8,00   & --- & Estrutura \\ \hline
+Filamento PLA para chassi           & Matéria-prima & 7,50   & --- & Estrutura \\ \hline
+Serviço de impressão 3D do chassi   & Montagem      & 40,00  & --- & Estrutura \\ \hline
+Parafusos do chassi                 & Fixadores     & 10,00  & --- & Estrutura \\ \hline
+\textbf{Total}                      & ---           & \textbf{167,50} & \textbf{---} & --- \\ \hline
+\end{tabular}
+\end{center}
+\end{table}
+
+\begin{table}[htpb]
+\begin{center}
+\caption{Justificativas da Estrutura para itens ou serviços trocados após a aquisição.}
+\begin{tabular}{|p{5cm}|p{16cm}|} \hline
+\textbf{Item ou serviço} & \textbf{Justificativa}  \\ \hline
+    --- &
+    Até o momento, não houve substituição de itens ou serviços após a aquisição, pois a seção apresenta apenas os valores previstos. \\ \hline
+\end{tabular}
+\end{center}
+\end{table}
+
 \end{landscape}


### PR DESCRIPTION
Closes #79 

Adicionei uma seção 5.1 para diferenciar o orçamento de estrutura dos demais

<img width="892" height="901" alt="Captura de tela de 2026-05-10 22-32-21" src="https://github.com/user-attachments/assets/ca70eebd-e7ab-43a4-9dfc-ab84e6840b5e" />

