### PR TITLE
fix(docs): corrige navegação da lista de tabelas e layout da capa

### DIFF
--- a/docs/relatorio/editaveis/08_cronograma.tex
+++ b/docs/relatorio/editaveis/08_cronograma.tex
@@ -2,9 +2,10 @@
 
 \chapter{Cronograma} 
 
-\begin{table}[htpb]
+\begin{table}[H]
 \begin{center}
 \caption{Cronograma geral.}
+\label{tab:cronograma-geral}
 \begin{tabular}{|c|c|c|}
 \hline
 \textbf{Geral}          & \textbf{Previsto} & \textbf{Realizado} \\ \hline
@@ -38,19 +39,19 @@ SW - 1.1 - Docs iniciais do projeto & 15/04/2026 & 01/05/2026 & 27/04/2026 & 02/
 SW - 1.2 - Definição do escopo & 15/04/2026 & 02/05/2026 & 27/04/2026 & 09/05/2026 & 1.1 & Thales, Manoela \\ \hline
 SW - 1.3 - Configuração GitHub & 15/04/2026 & 01/05/2026 & 27/04/2026 & 02/05/2026 & 1.1 & Thales, Manoela \\ \hline
 SW - 1.4 - Definição da arquitetura & 15/04/2026 & 04/05/2026 & 27/04/2026 & 09/05/2026 & 1.2 & Gustavo, Guilherme \\ \hline
-SW - 1.5 - Setup embarcado & 15/04/2026 & -- & 27/04/2026 & 07/05/2026 & --- & Victor, Gustavo \\ \hline
-SW - 1.6 - Flood Fill simulador & 15/04/2026 & -- & 27/04/2026 & 09/05/2026 & --- & Guilherme, Gustavo \\ \hline
+SW - 1.5 - Setup embarcado & 15/04/2026 & 15/04/2026 & 27/04/2026 & 07/05/2026 & --- & Victor, Gustavo \\ \hline
+SW - 1.6 - Flood Fill simulador & 15/04/2026 & 06/05/2026 & 27/04/2026 & 09/05/2026 & --- & Guilherme, Gustavo \\ \hline
 SW - 1.7 - Setup do backend & 15/04/2026 & 07/05/2026 & 27/04/2026 & 08/05/2026 & --- & Guilherme, Victor \\ \hline
+SW - 2.3 - BPMN e Casos de Uso & 30/04/2026 & 09/05/2026 & 11/05/2026 & 10/05/2026 & 1.2, 1.4 & Guilherme, Manoela \\ \hline
+SW - 2.4 - Endpoint telemetria & 30/04/2026 & 09/05/2026 & 11/05/2026 & 11/05/2026 & 1.7 & Thales, Gustavo \\ \hline
+SW - 2.5 - Modelagem do banco & 30/04/2026 & 07/05/2026 & 11/05/2026 & 09/05/2026 & 1.7 & Guilherme, Victor \\ \hline
+SW - 3.5 - Estrutura frontend & 30/04/2026 & 09/05/2026 & 11/05/2026 & 10/05/2026 & 1.4 & Manoela, Victor \\ \hline
 SW - 2.1 - Leitura de sensores & 14/05/2026 & -- & 25/05/2026 & -- & 1.5 & Thales, Manoela \\ \hline
 SW - 2.2 - Odometria e orientação & 14/05/2026 & -- & 25/05/2026 & -- & 1.5 & Gustavo, Victor \\ \hline
-SW - 2.3 - BPMN e Casos de Uso & 30/04/2026 & 09/05/2026 & 11/05/2026 & 10/05/2026 & 1.2, 1.4 & Guilherme, Manoela \\ \hline
-SW - 2.4 - Endpoint telemetria & 30/04/2026 & -- & 11/05/2026 & -- & 1.7 & Thales, Gustavo \\ \hline
-SW - 2.5 - Modelagem do banco & 30/04/2026 & 07/05/2026 & 11/05/2026 & 09/05/2026 & 1.7 & Guilherme, Victor \\ \hline
 SW - 3.1 - Flood Fill robô real & 14/05/2026 & -- & 25/05/2026 & -- & 1.6, 2.1, 2.2 & Gustavo, Victor \\ \hline
 SW - 3.2 - Ajuste de limiar & 14/05/2026 & -- & 25/05/2026 & -- & 2.1 & Thales, Manoela \\ \hline
 SW - 3.3 - Transmissão Wi-Fi & 14/05/2026 & -- & 25/05/2026 & -- & 1.5, 2.4 & Thales, Victor \\ \hline
 SW - 3.4 - Persistência corridas & 14/05/2026 & -- & 25/05/2026 & -- & 2.4, 2.5 & Guilherme, Gustavo \\ \hline
-SW - 3.5 - Estrutura frontend & 30/04/2026 & 09/05/2026 & 11/05/2026 & 10/05/2026 & 1.4 & Manoela, Victor \\ \hline
 SW - 4.1 - Detecção área objetivo & 28/05/2026 & -- & 08/06/2026 & -- & 3.1 & Guilherme, Manoela \\ \hline
 SW - 4.2 - Tela telemetria & 28/05/2026 & -- & 08/06/2026 & -- & 3.3, 3.5 & Thales, Gustavo \\ \hline
 SW - 4.3 - Histórico com filtros & 28/05/2026 & -- & 08/06/2026 & -- & 3.4, 3.5 & Manoela, Victor \\ \hline
@@ -71,9 +72,10 @@ SW - 6.4 - Ensaio apresentação & 25/06/2026 & -- & 06/07/2026 & -- & 6.1, 6.2,
 
 \section{Cronograma do subgrupo de energia}
 
-\begin{table}[htpb]
+\begin{table}[H]
 \begin{center}
 \caption{Cronograma do subgrupo de energia.}
+\label{tab:cronograma-energia}
 \resizebox{\textwidth}{!}{%
 \begin{tabular}{|c|c|c|c|c|c|c|}
 \hline
@@ -91,9 +93,10 @@ EN - 3.2 - Revisão final e ensaio para apresentação & 25/06/2026 & --- & 06/0
 
 \section{Entregáveis do subgrupo de energia}
 
-\begin{table}[htpb]
+\begin{table}[H]
 \begin{center}
 \caption{Entregáveis do subgrupo de energia.}
+\label{tab:entregaveis-energia}
 \begin{tabular}{|l|p{9cm}|c|}
 \hline
 \textbf{Entregável} & \textbf{Descrição} & \textbf{Marco} \\ \hline
@@ -108,9 +111,10 @@ Relatório de Autonomia & Validação do tempo de uso real em pista. & APT \\ \h
 
 
 
-\begin{table}[htpb]
+\begin{table}[H]
 \begin{center}
 \caption{Justificativas para atrasos ou não-conclusão de atividades.}
+\label{tab:justificativas-cronograma}
 \begin{tabular}{|c|c|} \hline
 \textbf{Atividade} & \textbf{Justificativa}  \\ \hline 
     3 - GHI &

--- a/docs/relatorio/fixos/customizacoes.sty
+++ b/docs/relatorio/fixos/customizacoes.sty
@@ -52,28 +52,27 @@
 %		\textbf{\textsc{Trabalho de Conclusão de Curso}}
 %	\end{huge}
 
-    \vspace*{2.9in}
+    \vspace*{2.6in}
 	{\textbf{\large\imprimirinstituicao}}
 	\par
 	{\textbf{\large\imprimircurso}}
 
-	\vspace{1.5in}
+	\vspace{1.2in}
 
     {\ABNTEXchapterfont\bfseries\LARGE\imprimirtitulo}
-    \vspace*{\fill}
+    \vspace{0.5in}
 
 	\begin{flushright}
-    	\textbf{{\large{Autor: \imprimirautor}}}
+    	\textbf{{\normalsize{Autor: \imprimirautor}}}
 		\par
-    	\textbf{{\large{Orientador: \imprimirorientador}}}
+		\vspace{0.1in}
+    	\textbf{{\normalsize{Orientador: \imprimirorientador}}}
 	\end{flushright}
 
-    \vspace*{0.2in}
+    \vspace{0.5in}
     \textbf{{\large\imprimirlocal}}
     \par
     \textbf{{\large\imprimirdata}}
-
-    \vspace*{1in}
   \end{capa}
 }
 


### PR DESCRIPTION
- 08_cronograma.tex: troca [htpb] por [H] nas tabelas para fixá-las no local correto, evitando que flutuem e quebrem os links da lista de tabelas. Adiciona labels faltantes.
- customizacoes.sty: reorganiza espaçamentos da capa para que os 19 nomes dos autores não invadam a área verde inferior e para que a data volte a ser renderizada.