### PR TITLE
T3: setup do ambiente de testes do backend (pytest + cobertura)

### DIFF
--- a/src/backend/.gitignore
+++ b/src/backend/.gitignore
@@ -1,0 +1,6 @@
+# Artefatos de testes
+.pytest_cache/
+htmlcov/
+.coverage
+.coverage.*
+coverage.xml

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -14,8 +14,16 @@ Backend responsável por receber, processar e disponibilizar dados de telemetria
 backend/
 ├── app/
 │   ├── routes/
-│   │   └── health.py
+│   │   ├── health.py
+│   │   └── telemetria.py
+│   ├── models/
+│   ├── schemas/
 │   └── main.py
+├── tests/
+│   ├── conftest.py
+│   ├── test_health.py
+│   └── test_telemetria.py
+├── pytest.ini
 ├── requirements.txt
 └── README.md
 ```
@@ -99,6 +107,51 @@ A aplicação ficará disponível em:
 ```bash
 http://localhost:8000
 ```
+
+---
+
+## ✅ Testes automatizados (pytest + cobertura)
+
+A suíte de testes fica em `tests/` e roda sobre um **banco SQLite isolado em
+memória** — não toca no `micromouse.db`. A configuração está no `pytest.ini`
+(cobertura via `pytest-cov` já habilitada).
+
+```bash
+# com o venv ativado e dentro de src/backend
+pip install -r requirements.txt   # garante pytest e pytest-cov
+pytest                            # roda tudo + relatório de cobertura no terminal
+```
+
+O relatório HTML detalhado é gerado em `htmlcov/index.html`. Para rodar um
+arquivo ou teste específico:
+
+```bash
+pytest tests/test_telemetria.py
+pytest tests/test_telemetria.py::test_post_telemetria_labirinto_inexistente_retorna_404
+```
+
+### Fixtures disponíveis (em `tests/conftest.py`)
+
+Use-as nos novos testes — basta declará-las como argumento da função:
+
+| Fixture             | Para que serve                                                        |
+| ------------------- | --------------------------------------------------------------------- |
+| `client`            | `TestClient` da API já conectado ao banco de teste.                   |
+| `db_session`        | Sessão SQLAlchemy para montar dados direto no banco.                  |
+| `labirintos`        | Semeia os 3 labirintos e retorna `{"4x4": id, "8x8": id, "16x16": id}`. |
+| `pacote_telemetria` | Construtor de payload de telemetria válido (aceita `**overrides`).    |
+
+Exemplo (ver `tests/test_telemetria.py`):
+
+```python
+def test_exemplo(client, labirintos, pacote_telemetria):
+    resp = client.post("/telemetria", json=pacote_telemetria(labirinto_id=labirintos["4x4"]))
+    assert resp.status_code == 201
+```
+
+> A meta da entrega é **cobertura ≥ 70%**. Os testes-modelo já cobrem health e
+> os casos básicos do `POST /telemetria`; as suítes completas (WebSocket,
+> models/schemas, histórico) são as Tarefas T6–T9.
 
 ---
 

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -112,6 +112,23 @@ http://localhost:8000
 
 ## ✅ Testes automatizados (pytest + cobertura)
 
+> 🤖 **Precisa do robô / ESP32 / sensores para rodar os testes? NÃO.**
+> Os testes automatizados rodam **100% sem hardware** e sem internet. Você só
+> precisa de **Python + as dependências do `requirements.txt`**. Não é preciso
+> ter o ESP32, o robô montado, sensores calibrados, Wi-Fi ou MQTT.
+>
+> Por quê:
+> - O banco usado é um **SQLite em memória**, criado e destruído a cada teste
+>   (não toca no `micromouse.db` nem em banco nenhum de verdade).
+> - Os pacotes de telemetria são **fabricados dentro do próprio teste** (fixture
+>   `pacote_telemetria`), simulando exatamente o que o robô enviaria — então não
+>   há robô de verdade enviando dados.
+> - O servidor sobe em memória pelo `TestClient`; **não** é preciso rodar o
+>   `uvicorn` à parte.
+>
+> O hardware (ESP enviando telemetria real) só importa para a **integração de
+> sistema** / demonstração do robô — que é outra entrega, não estes testes.
+
 A suíte de testes fica em `tests/` e roda sobre um **banco SQLite isolado em
 memória** — não toca no `micromouse.db`. A configuração está no `pytest.ini`
 (cobertura via `pytest-cov` já habilitada).

--- a/src/backend/pytest.ini
+++ b/src/backend/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+pythonpath = .
+testpaths = tests
+addopts = -ra --cov=app --cov-report=term-missing --cov-report=html:htmlcov

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -24,6 +24,8 @@ orjson==3.11.9
 pydantic==2.13.4
 pydantic_core==2.46.4
 Pygments==2.20.0
+pytest==8.3.4
+pytest-cov==6.0.0
 python-dotenv==1.2.2
 python-multipart==0.0.27
 PyYAML==6.0.3

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -1,0 +1,112 @@
+"""Configuração compartilhada dos testes do backend.
+
+Cria um banco SQLite isolado em memória (não toca em ``micromouse.db``),
+redireciona as sessões da aplicação para esse banco e oferece fixtures
+reutilizáveis pelas demais suítes (Tarefas T6–T9):
+
+- ``client``: ``TestClient`` da API com o banco de teste já conectado;
+- ``db_session``: sessão para montar dados diretamente no banco;
+- ``labirintos``: semeia os três labirintos padrão (4x4, 8x8, 16x16);
+- ``pacote_telemetria``: monta um payload de telemetria válido.
+"""
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app import database
+from app.database import Base, get_db
+from app.main import app
+from app.models.models import DimensaoLabirinto, Labirinto
+
+
+@pytest.fixture()
+def engine():
+    """Engine SQLite em memória, isolado por teste.
+
+    ``StaticPool`` mantém a mesma conexão, garantindo que o banco em memória
+    persista entre as várias sessões abertas durante um teste.
+    """
+    eng = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=eng)
+    yield eng
+    Base.metadata.drop_all(bind=eng)
+    eng.dispose()
+
+
+@pytest.fixture()
+def session_factory(engine):
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def db_session(session_factory):
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def client(session_factory, monkeypatch):
+    """``TestClient`` com as sessões da aplicação apontando para o banco de teste.
+
+    Sobrescreve ``get_db`` (usado pelas rotas HTTP) e o ``SessionLocal``
+    (instanciado diretamente pelo endpoint WebSocket) para o banco isolado.
+    """
+    def _get_db_override():
+        db = session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = _get_db_override
+    monkeypatch.setattr(database, "SessionLocal", session_factory)
+    monkeypatch.setattr("app.routes.telemetria.SessionLocal", session_factory)
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def labirintos(db_session):
+    """Semeia os três labirintos padrão e retorna ``{dimensao: id}``."""
+    labs = {
+        "4x4": Labirinto(dimensao=DimensaoLabirinto.quatro_x_quatro),
+        "8x8": Labirinto(dimensao=DimensaoLabirinto.oito_x_oito),
+        "16x16": Labirinto(dimensao=DimensaoLabirinto.dezesseis_x_dezesseis),
+    }
+    db_session.add_all(list(labs.values()))
+    db_session.commit()
+    return {dim: lab.id for dim, lab in labs.items()}
+
+
+@pytest.fixture()
+def pacote_telemetria():
+    """Devolve um construtor de payload de telemetria válido para os testes."""
+    def _build(labirinto_id=None, corrida_id=None, **overrides):
+        payload = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "posicao_x": 0,
+            "posicao_y": 0,
+            "nivel_bateria": 100.0,
+        }
+        if labirinto_id is not None:
+            payload["labirinto_id"] = labirinto_id
+        if corrida_id is not None:
+            payload["corrida_id"] = corrida_id
+        payload.update(overrides)
+        return payload
+
+    return _build

--- a/src/backend/tests/test_health.py
+++ b/src/backend/tests/test_health.py
@@ -1,0 +1,7 @@
+"""Teste-modelo do endpoint de health (base para a Tarefa T9 / #126)."""
+
+
+def test_health_retorna_ok(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "OK"}

--- a/src/backend/tests/test_telemetria.py
+++ b/src/backend/tests/test_telemetria.py
@@ -1,0 +1,27 @@
+"""Testes-modelo da rota POST /telemetria.
+
+Servem de base para a Tarefa T6 (#123). Mostram o uso das fixtures
+``client``, ``labirintos`` e ``pacote_telemetria`` do ``conftest.py``.
+A suíte completa (mais casos de borda) é responsabilidade da T6.
+"""
+
+
+def test_post_telemetria_cria_corrida_e_persiste_evento(client, labirintos, pacote_telemetria):
+    resp = client.post("/telemetria", json=pacote_telemetria(labirinto_id=labirintos["4x4"]))
+
+    assert resp.status_code == 201
+    corpo = resp.json()
+    assert corpo["posicao_x"] == 0
+    assert corpo["nivel_bateria"] == 100.0
+    assert corpo["corrida_id"] >= 1
+
+
+def test_post_telemetria_sem_corrida_ou_labirinto_retorna_422(client, pacote_telemetria):
+    # Sem corrida_id nem labirinto_id: o validador do schema deve rejeitar.
+    resp = client.post("/telemetria", json=pacote_telemetria())
+    assert resp.status_code == 422
+
+
+def test_post_telemetria_labirinto_inexistente_retorna_404(client, pacote_telemetria):
+    resp = client.post("/telemetria", json=pacote_telemetria(labirinto_id=9999))
+    assert resp.status_code == 404


### PR DESCRIPTION
## 1. Descrição

Configura a infraestrutura de testes automatizados do backend (FastAPI), que até então não existia. Adiciona `pytest` + `pytest-cov`, um banco SQLite isolado em memória para os testes (sem tocar no `micromouse.db`), fixtures reutilizáveis e testes-modelo já passando. Este é o setup (Tarefa T3) que **destrava as Tarefas T6–T9** (testes de rota, WebSocket, models/schemas e histórico) — cada pessoa só declara as fixtures e escreve os `assert`.

## 2. Relacionado à Issue
Closes #120

## 3. Alterações Realizadas
- Adicionados `pytest` e `pytest-cov` ao `requirements.txt`
- `pytest.ini` configurando `pythonpath`, `testpaths` e relatório de cobertura (`--cov=app`, term + HTML)
- `tests/conftest.py` com banco SQLite isolado em memória (StaticPool) e fixtures: `client`, `db_session`, `labirintos`, `pacote_telemetria`; redireciona `get_db` e `SessionLocal` (este último usado pelo WebSocket) para o banco de teste
- Testes-modelo: `tests/test_health.py` e `tests/test_telemetria.py` (base para T6/T9)
- `.gitignore` do backend para artefatos de teste (`htmlcov/`, `.coverage`, `.pytest_cache/`)
- README: seção de execução dos testes + tabela de fixtures + estrutura atualizada

## 4. Tipo de Mudança
- [x] **feature/** (Nova funcionalidade de software)

## 5. Como Testar / Validar
- Passo 1: `cd src/backend` e ativar o venv
- Passo 2: `pip install -r requirements.txt`
- Passo 3: `pytest`
- Resultado esperado: `4 passed` e cobertura total **≥ 70%** (atualmente 76%); relatório HTML em `htmlcov/index.html`

## 6. Screenshots / Evidências

```
tests/test_health.py .                                                   [ 25%]
tests/test_telemetria.py ...                                             [100%]
TOTAL                         163     39    76%
========================= 4 passed, 1 warning in 0.14s =========================
```
