### PR TITLE
T5: setup do Playwright para testes E2E da aplicacao web

### DIFF
--- a/src/frontend/.gitignore
+++ b/src/frontend/.gitignore
@@ -14,6 +14,10 @@ dist-ssr
 
 # Artefatos de testes
 coverage
+test-results
+playwright-report
+blob-report
+/playwright/.cache
 
 # Editor directories and files
 .vscode/*

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -60,3 +60,52 @@ it('exemplo', () => {
 
 > O smoke test atual cobre o `App` (navegação + página inicial). As suítes
 > completas das páginas e componentes são as Tarefas T10–T12.
+
+## 🎭 Testes E2E / sistema (Playwright)
+
+Diferente dos testes acima (que rodam em `jsdom`), os testes **E2E** abrem a
+aplicação em um **navegador real** (Chromium headless) e validam os fluxos do
+ponto de vista do usuário — são os testes de sistema/funcional exigidos na
+seção 7.5 do relatório.
+
+### Como rodar
+
+```bash
+# dentro de src/frontend
+npm install                  # instala dependências (inclui @playwright/test)
+npx playwright install chromium   # baixa o navegador (só na primeira vez)
+npm run e2e                  # roda os testes E2E (headless)
+npm run e2e:ui               # modo interativo (UI do Playwright)
+npm run e2e:report           # abre o último relatório HTML
+```
+
+Não precisa subir o frontend manualmente: o `playwright.config.js` tem um
+`webServer` que executa `npm run dev` automaticamente antes dos testes.
+
+### Onde ficam os testes
+
+- Os specs E2E ficam em **`e2e/`** com sufixo `.spec.js` (ex.: `e2e/smoke.spec.js`).
+  Eles **não** são executados pelo Vitest (o Vitest está restrito a `src/`).
+- Configuração em `playwright.config.js`.
+
+### ⚠️ E2E que dependem do backend (Tarefas T13–T15)
+
+O `webServer` padrão sobe **apenas o frontend** — suficiente para o smoke test e
+fluxos de navegação. Os E2E que precisam de **dados reais da API** (telemetria,
+histórico) devem subir também o backend. Para isso, transforme o `webServer` em
+uma lista no `playwright.config.js`:
+
+```js
+webServer: [
+  { command: 'npm run dev', url: 'http://localhost:5173', reuseExistingServer: !process.env.CI },
+  {
+    // backend: ajuste o caminho do uvicorn ao seu ambiente (venv)
+    command: 'cd ../backend && venv/bin/python -m uvicorn app.main:app --port 8000',
+    url: 'http://localhost:8000/health',
+    reuseExistingServer: !process.env.CI,
+  },
+],
+```
+
+> Os fluxos E2E devem seguir o **roteiro de testes funcionais** (Tarefa T2).
+> O molde inicial está em `e2e/smoke.spec.js`.

--- a/src/frontend/e2e/smoke.spec.js
+++ b/src/frontend/e2e/smoke.spec.js
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test'
+
+// Teste-fumaça (smoke test) E2E: garante que a aplicação carrega no navegador
+// e que a navegação principal funciona. Serve de molde para as Tarefas
+// T13–T15 (fluxos de telemetria, histórico e reconexão).
+
+test('a aplicação carrega e exibe a navegação principal', async ({ page }) => {
+  await page.goto('/')
+
+  await expect(page.getByRole('heading', { name: 'Micromouse Telemetria' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Telemetria ao Vivo' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'Histórico' })).toBeVisible()
+})
+
+test('navega da telemetria para o histórico pela barra de navegação', async ({ page }) => {
+  await page.goto('/')
+
+  await expect(page.getByRole('heading', { name: 'Painel de Controle' })).toBeVisible()
+
+  await page.getByRole('link', { name: 'Histórico' }).click()
+
+  await expect(page).toHaveURL(/\/historico$/)
+  await expect(page.getByRole('heading', { name: 'Histórico de Corridas' })).toBeVisible()
+})

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -824,6 +825,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3003,6 +3020,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -10,7 +10,10 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:report": "playwright show-report"
   },
   "dependencies": {
     "react": "^19.2.5",
@@ -19,6 +22,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/src/frontend/playwright.config.js
+++ b/src/frontend/playwright.config.js
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// Configuração dos testes E2E (sistema/funcional) da aplicação web.
+// Os testes ficam em ./e2e e rodam contra o frontend servido pelo Vite.
+//
+// O `webServer` abaixo sobe apenas o FRONTEND, o suficiente para o smoke test
+// e para os fluxos de UI. Os testes E2E que dependem de dados reais do backend
+// (Tarefas T13–T15) devem subir também a API — veja a nota no README
+// (seção "Testes E2E") sobre como adicionar o backend ao `webServer`.
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+})

--- a/src/frontend/vite.config.js
+++ b/src/frontend/vite.config.js
@@ -11,6 +11,8 @@ export default defineConfig({
     globals: true,
     // Carrega matchers do jest-dom (toBeInTheDocument etc.) antes dos testes.
     setupFiles: './src/test/setup.js',
+    // Restringe o Vitest aos testes em src/; os specs E2E (Playwright) ficam em e2e/.
+    include: ['src/**/*.{test,spec}.{js,jsx}'],
     css: true,
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## 1. Descrição

Configura o **Playwright** como ferramenta de testes E2E (sistema/funcional) da aplicação web, com um smoke test já passando. Este é o setup (Tarefa T5) que **destrava as Tarefas T13–T15** (fluxos de telemetria ao vivo, histórico e reconexão). Diferente do Vitest (jsdom), os testes E2E abrem a aplicação em um navegador real (Chromium headless).

## 2. Relacionado à Issue
Closes #122

## 3. Alterações Realizadas
- Adicionado `@playwright/test` às `devDependencies` e scripts `e2e`, `e2e:ui`, `e2e:report`
- `playwright.config.js`: `testDir: e2e`, `baseURL`, projeto Chromium e `webServer` subindo o frontend (`npm run dev`) automaticamente
- `e2e/smoke.spec.js`: carregamento da app + navegação entre telemetria e histórico
- `vite.config.js`: Vitest restrito a `src/` para **não** coletar os specs E2E (`e2e/*.spec.js`)
- `.gitignore`: artefatos do Playwright (`test-results`, `playwright-report`, etc.)
- README: seção de testes E2E (como rodar, onde ficam, e como plugar o backend para os E2E que dependem de dados reais — T13–T15)

## 4. Tipo de Mudança
- [x] **feature/** (Nova funcionalidade de software)

## 5. Como Testar / Validar
- Passo 1: `cd src/frontend`
- Passo 2: `npm install`
- Passo 3: `npx playwright install chromium` (só na primeira vez)
- Passo 4: `npm run e2e`
- Resultado esperado: `2 passed`. O `npm test` (Vitest) continua verde e ignora os specs E2E.

## 6. Screenshots / Evidências

```
Running 2 tests using 2 workers
  2 passed (6.8s)
```

> Observação: o `webServer` padrão sobe apenas o frontend (suficiente para o smoke test). Os E2E que precisam de dados reais da API (T13–T15) devem subir o backend também — instruções no README.
