### PR TITLE
test(frontend): adiciona testes unitarios dos componentes Layout e Ma…

### DIFF
--- a/src/frontend/src/components/__tests__/Layout.test.jsx
+++ b/src/frontend/src/components/__tests__/Layout.test.jsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import Layout from '../Layout'
+
+function renderLayout(initialRoute = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialRoute]}>
+      <Routes>
+        <Route path="/" element={<Layout />}>
+          <Route index element={<h1>Painel de Controle</h1>} />
+          <Route path="historico" element={<h1>Histórico de Corridas</h1>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('Layout', () => {
+  it('renderiza o titulo no header', () => {
+    renderLayout()
+    expect(screen.getByText('Micromouse Telemetria')).toBeInTheDocument()
+  })
+
+  it('renderiza os dois links de navegacao', () => {
+    renderLayout()
+    expect(screen.getByText('Telemetria ao Vivo')).toBeInTheDocument()
+    expect(screen.getByText('Histórico')).toBeInTheDocument()
+  })
+
+  it('link Telemetria ao Vivo esta ativo na rota /', () => {
+    renderLayout('/')
+    const linkTelemetria = screen.getByText('Telemetria ao Vivo')
+    const linkHistorico = screen.getByText('Histórico')
+
+    expect(linkTelemetria).toHaveStyle('color: #61dafb')
+    expect(linkHistorico).toHaveStyle('color: #ccc')
+  })
+
+  it('link Historico esta ativo na rota /historico', () => {
+    renderLayout('/historico')
+    const linkTelemetria = screen.getByText('Telemetria ao Vivo')
+    const linkHistorico = screen.getByText('Histórico')
+
+    expect(linkHistorico).toHaveStyle('color: #61dafb')
+    expect(linkTelemetria).toHaveStyle('color: #ccc')
+  })
+
+  it('navega de Telemetria para Historico e volta', async () => {
+    const user = userEvent.setup()
+    renderLayout('/')
+
+    expect(screen.getByText('Painel de Controle')).toBeInTheDocument()
+
+    await user.click(screen.getByText('Histórico'))
+    expect(screen.getByText('Histórico de Corridas')).toBeInTheDocument()
+
+    await user.click(screen.getByText('Telemetria ao Vivo'))
+    expect(screen.getByText('Painel de Controle')).toBeInTheDocument()
+  })
+})

--- a/src/frontend/src/components/__tests__/MazeMap.test.jsx
+++ b/src/frontend/src/components/__tests__/MazeMap.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import MazeMap from '../MazeMap'
+
+describe('MazeMap', () => {
+  it('renderiza com tamanho padrao 4x4', () => {
+    render(<MazeMap />)
+    expect(screen.getByText('Mapa do Labirinto (4x4)')).toBeInTheDocument()
+  })
+
+  it('renderiza 16 celulas para grid 4x4', () => {
+    const { container } = render(<MazeMap size={4} />)
+    const grid = container.querySelector('div > div > div:last-child')
+    expect(grid.children).toHaveLength(16)
+  })
+
+  it('renderiza 64 celulas para grid 8x8', () => {
+    const { container } = render(<MazeMap size={8} />)
+    expect(screen.getByText('Mapa do Labirinto (8x8)')).toBeInTheDocument()
+    const grid = container.querySelector('div > div > div:last-child')
+    expect(grid.children).toHaveLength(64)
+  })
+
+  it('renderiza 256 celulas para grid 16x16', () => {
+    const { container } = render(<MazeMap size={16} />)
+    expect(screen.getByText('Mapa do Labirinto (16x16)')).toBeInTheDocument()
+    const grid = container.querySelector('div > div > div:last-child')
+    expect(grid.children).toHaveLength(256)
+  })
+
+  it('grid tem colunas corretas para o tamanho informado', () => {
+    const { container } = render(<MazeMap size={8} />)
+    const grid = container.querySelector('div > div > div:last-child')
+    expect(grid).toHaveStyle('grid-template-columns: repeat(8, 1fr)')
+  })
+
+  it('exibe mensagem de aguardando dados', () => {
+    render(<MazeMap />)
+    expect(screen.getByText(/aguardando dados de mapeamento/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## 1. Descrição
Criação da suíte de testes unitários dos componentes compartilhados do frontend (Layout e MazeMap), conforme definido na Tarefa T12. Os testes cobrem renderização, navegação entre rotas, estilos de link ativo e renderização dinâmica do grid do labirinto por dimensão.
OBS: Não tem botão para troca de tamanho de grid ainda, testei alterando manualmente no arquivo!!!
## 2. Relacionado à Issue
Closes #129

## 3. Alterações Realizadas
- Criação de src/components/__tests__/Layout.test.jsx com 5 testes: renderização do header e links, estilo ativo por rota (/ e /historico), e navegação
  entre páginas
- Criação de src/components/__tests__/MazeMap.test.jsx com 6 testes: renderização padrão 4x4, contagem de células por dimensão (4x4, 8x8, 16x16), colunas
   corretas no grid, e mensagem de aguardando dados
- Total: 11 testes novos, todos passando

## 4. Tipo de Mudança
[Marque com um 'x' dentro dos colchetes a opção que representa o que você fez]
- [X] **feature/** (Nova funcionalidade de software)
- [ ] **fix/** (Correção de bug/problema)
- [ ] **docs/** (Documentação no relatório ou no repositório)
- [ ] **hw/** (Alterações em hardware - esquemáticos, PCB)
- [ ] **mec/** (Alterações em arquivos mecânicos - CAD)
- [ ] **refactor/** (Refatoração de código sem mudança de comportamento)

## 5. Como Testar / Validar
- Passo 1: cd src/frontend
- Passo 2: npm install (se necessário)
- Passo 3: npx vitest run --reporter=verbose
- Resultado esperado: 13 testes passando (11 novos + 2 do smoke test existente)