### PR TITLE
feat(web): telemetria ao vivo + e2e de reconexão (#19, #132)

### DIFF
--- a/src/frontend/docs/structure.md
+++ b/src/frontend/docs/structure.md
@@ -36,11 +36,11 @@ O roteamento é gerenciado pelo `react-router-dom`, utilizando um layout base pa
 Componente pai que contém o **Header** e a **Navegação**. Ele utiliza o `<Outlet />` para renderizar as páginas específicas.
 
 ### 2. `Telemetry` (Página)
-Preparado para consumir dados em tempo real. Exibe:
-- Status da bateria.
-- Cronômetro de corrida.
-- Velocidade e trajetória.
-- Componente `MazeMap`.
+Consome o WebSocket `/ws/telemetria` (via hook `useTelemetry`) e exibe em tempo real:
+- Status da conexão (Conectando/Conectado/Desconectado).
+- Bateria, velocidade média e tempo decorrido.
+- Indicador de desafio cumprido (Sim/Não) — derivado de o robô alcançar o centro.
+- Seletor de tamanho do labirinto (4x4, 8x8, 16x16) e o componente `MazeMap`.
 
 ### 3. `History` (Página)
 Interface de consulta ao banco de dados (SQLite via FastAPI).
@@ -48,7 +48,9 @@ Interface de consulta ao banco de dados (SQLite via FastAPI).
 - Indicador de "Desafio Cumprido".
 
 ### 4. `MazeMap` (Componente Reutilizável)
-Responsável por desenhar a grade do labirinto e a posição atual (X, Y) do Micromouse. No momento, funciona como um placeholder para a lógica de grid.
+Desenha a grade NxN do labirinto e sobrepõe o trajeto percorrido, a posição atual (X, Y) do Micromouse e a célula de chegada (bloco 2x2 central), com legenda.
+
+> **Configuração da API:** o endereço do WebSocket pode ser definido pela variável de ambiente `VITE_WS_URL` (ex.: `ws://localhost:8000/ws/telemetria`). Sem ela, o padrão é `ws://<host>:8000/ws/telemetria`.
 
 ---
 

--- a/src/frontend/e2e/reconexao.spec.js
+++ b/src/frontend/e2e/reconexao.spec.js
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test'
+
+// E2E (Tarefa T15, issue #132): robustez de conexão/reconexão do WebSocket de
+// telemetria. Automatiza o roteiro manual descrito na issue #24.
+//
+// Em vez de subir o backend, injetamos um WebSocket falso no navegador ANTES da
+// aplicação carregar e controlamos abertura, mensagens e queda a partir do
+// teste. Assim o cenário fica determinístico e não depende de rede real.
+//
+// Observação: a app roda com <StrictMode>, que no modo dev monta o efeito duas
+// vezes — por isso operamos sempre sobre a ÚLTIMA conexão criada (a ativa) e o
+// socket falso ignora chamadas após ser fechado.
+
+const TELEMETRIA_INICIAL = {
+  id: 1, corrida_id: 1, posicao_x: 0, posicao_y: 0,
+  nivel_bateria: 100, velocidade: 0.4, timestamp: '2026-05-10T12:00:00Z',
+}
+const TELEMETRIA_POS_RECONEXAO = {
+  id: 2, corrida_id: 1, posicao_x: 1, posicao_y: 1,
+  nivel_bateria: 80, velocidade: 0.6, timestamp: '2026-05-10T12:00:05Z',
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    class FakeWebSocket {
+      constructor(url) {
+        this.url = url
+        this._fechada = false
+        window.__wsInstances.push(this)
+      }
+      send() {}
+      close() {
+        this._fechada = true
+        if (this.onclose) this.onclose({})
+      }
+      // Disparados pelo teste para simular o servidor:
+      abrir() {
+        if (!this._fechada && this.onopen) this.onopen({})
+      }
+      enviar(dado) {
+        if (!this._fechada && this.onmessage) this.onmessage({ data: JSON.stringify(dado) })
+      }
+      derrubar() {
+        this._fechada = true
+        if (this.onclose) this.onclose({})
+      }
+    }
+    window.__wsInstances = []
+    window.WebSocket = FakeWebSocket
+  })
+})
+
+const abrirUltima = (page) => page.evaluate(() => window.__wsInstances.at(-1).abrir())
+const enviarUltima = (page, dado) =>
+  page.evaluate((d) => window.__wsInstances.at(-1).enviar(d), dado)
+const derrubarUltima = (page) => page.evaluate(() => window.__wsInstances.at(-1).derrubar())
+
+test('perda de conexão é sinalizada, reconecta e os dados voltam a atualizar', async ({ page }) => {
+  await page.goto('/')
+  await page.waitForFunction(() => window.__wsInstances && window.__wsInstances.length >= 1)
+
+  // 1. Conexão inicial estabelecida + telemetria atualizando a GUI.
+  await abrirUltima(page)
+  await expect(page.getByText(/Conectado/)).toBeVisible()
+  await enviarUltima(page, TELEMETRIA_INICIAL)
+  await expect(page.getByText(/100%/)).toBeVisible()
+
+  const conexoesAntes = await page.evaluate(() => window.__wsInstances.length)
+
+  // 2. Queda de conexão durante a telemetria -> indicador de conexão perdida.
+  await derrubarUltima(page)
+  await expect(page.getByText(/Desconectado/)).toBeVisible()
+
+  // 3. Reconexão automática: o hook abre uma nova conexão sozinho.
+  await page.waitForFunction(
+    (n) => window.__wsInstances.length > n,
+    conexoesAntes,
+    { timeout: 7000 },
+  )
+
+  // 4. Conexão restaurada.
+  await abrirUltima(page)
+  await expect(page.getByText(/Conectado/)).toBeVisible()
+
+  // 5. Os dados voltam a atualizar após a reconexão.
+  await enviarUltima(page, TELEMETRIA_POS_RECONEXAO)
+  await expect(page.getByText(/80%/)).toBeVisible()
+  await expect(page.getByText(/\(1, 1\)/)).toBeVisible()
+})

--- a/src/frontend/src/components/MazeMap.jsx
+++ b/src/frontend/src/components/MazeMap.jsx
@@ -1,47 +1,102 @@
-export default function MazeMap({ size = 4 }) {
+import { ehChegada } from '../utils/maze';
+
+const CORES = {
+  posicao: '#1565c0', // posição atual do robô
+  chegada: '#c8e6c9', // bloco 2x2 central (objetivo)
+  inicio: '#ffe0b2', // primeira célula do trajeto
+  trajeto: '#bbdefb', // células já visitadas
+  vazia: 'white',
+};
+
+// Desenha a grade NxN do labirinto e sobrepõe o trajeto percorrido, a posição
+// atual do micromouse e a célula de chegada. A célula i (ordem row-major) mapeia
+// para x = coluna (i % size) e y = linha (i / size), com a origem no topo-esquerda.
+export default function MazeMap({ size = 4, trajeto = [], posicaoAtual = null }) {
   const totalCells = size * size;
+  const visitadas = new Set(trajeto.map((p) => `${p.x},${p.y}`));
+  const inicio = trajeto[0] ?? null;
+
+  function corDaCelula(x, y) {
+    if (posicaoAtual && posicaoAtual.x === x && posicaoAtual.y === y) return CORES.posicao;
+    if (ehChegada(x, y, size)) return CORES.chegada;
+    if (inicio && inicio.x === x && inicio.y === y) return CORES.inicio;
+    if (visitadas.has(`${x},${y}`)) return CORES.trajeto;
+    return CORES.vazia;
+  }
 
   return (
     <div style={styles.container}>
-      <h3 style={{ margin: 0, color: '#666' }}>Mapa do Labirinto ({size}x{size})</h3>
-      <p style={{ fontSize: '14px', color: '#999' }}>Aguardando dados de mapeamento do ESP32...</p>
-      
-      {/* Grid dinâmico baseado na prop 'size' */}
-      <div style={{
-        ...styles.grid,
-        gridTemplateColumns: `repeat(${size}, 1fr)`
-      }}>
-        {Array.from({ length: totalCells }).map((_, i) => (
-          <div key={i} style={styles.cell}></div>
-        ))}
+      <h3 style={styles.titulo}>Mapa do Labirinto ({size}x{size})</h3>
+      {trajeto.length === 0 && (
+        <p style={styles.aviso}>Aguardando dados de telemetria do ESP32…</p>
+      )}
+
+      <div
+        role="grid"
+        aria-label={`Labirinto ${size}x${size}`}
+        style={{ ...styles.grid, gridTemplateColumns: `repeat(${size}, 1fr)` }}
+      >
+        {Array.from({ length: totalCells }).map((_, i) => {
+          const x = i % size;
+          const y = Math.floor(i / size);
+          return <div key={i} style={{ ...styles.cell, backgroundColor: corDaCelula(x, y) }} />;
+        })}
+      </div>
+
+      <div style={styles.legenda}>
+        <ItemLegenda cor={CORES.inicio} texto="Início" />
+        <ItemLegenda cor={CORES.trajeto} texto="Trajeto" />
+        <ItemLegenda cor={CORES.posicao} texto="Posição atual" />
+        <ItemLegenda cor={CORES.chegada} texto="Chegada" />
       </div>
     </div>
+  );
+}
+
+function ItemLegenda({ cor, texto }) {
+  return (
+    <span style={styles.legendaItem}>
+      <span style={{ ...styles.legendaCor, backgroundColor: cor }} />
+      {texto}
+    </span>
   );
 }
 
 const styles = {
   container: {
     width: '100%',
-    height: '400px',
-    border: '2px dashed #ccc',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#f9f9f9',
-    borderRadius: '8px'
+    padding: '1rem',
+    border: '1px solid #ddd',
+    borderRadius: '8px',
+    backgroundColor: '#fafafa',
   },
+  titulo: { margin: '0 0 0.25rem', color: '#444' },
+  aviso: { fontSize: '14px', color: '#999', marginTop: 0 },
   grid: {
     display: 'grid',
-    gridTemplateColumns: 'repeat(4, 1fr)',
     gap: '2px',
-    marginTop: '20px',
-    width: '250px',
-    height: '150px',
-    backgroundColor: '#ddd',
-    border: '2px solid #999'
+    width: 'min(360px, 100%)',
+    aspectRatio: '1 / 1',
+    margin: '0.5rem 0',
+    backgroundColor: '#999',
+    border: '2px solid #999',
   },
   cell: {
-    backgroundColor: 'white'
-  }
+    border: '1px solid #e0e0e0',
+  },
+  legenda: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '12px',
+    fontSize: '13px',
+    color: '#555',
+  },
+  legendaItem: { display: 'inline-flex', alignItems: 'center', gap: '4px' },
+  legendaCor: {
+    width: '14px',
+    height: '14px',
+    borderRadius: '3px',
+    border: '1px solid #ccc',
+    display: 'inline-block',
+  },
 };

--- a/src/frontend/src/components/__tests__/MazeMap.test.jsx
+++ b/src/frontend/src/components/__tests__/MazeMap.test.jsx
@@ -9,33 +9,29 @@ describe('MazeMap', () => {
   })
 
   it('renderiza 16 celulas para grid 4x4', () => {
-    const { container } = render(<MazeMap size={4} />)
-    const grid = container.querySelector('div > div > div:last-child')
-    expect(grid.children).toHaveLength(16)
+    render(<MazeMap size={4} />)
+    expect(screen.getByRole('grid').children).toHaveLength(16)
   })
 
   it('renderiza 64 celulas para grid 8x8', () => {
-    const { container } = render(<MazeMap size={8} />)
+    render(<MazeMap size={8} />)
     expect(screen.getByText('Mapa do Labirinto (8x8)')).toBeInTheDocument()
-    const grid = container.querySelector('div > div > div:last-child')
-    expect(grid.children).toHaveLength(64)
+    expect(screen.getByRole('grid').children).toHaveLength(64)
   })
 
   it('renderiza 256 celulas para grid 16x16', () => {
-    const { container } = render(<MazeMap size={16} />)
+    render(<MazeMap size={16} />)
     expect(screen.getByText('Mapa do Labirinto (16x16)')).toBeInTheDocument()
-    const grid = container.querySelector('div > div > div:last-child')
-    expect(grid.children).toHaveLength(256)
+    expect(screen.getByRole('grid').children).toHaveLength(256)
   })
 
   it('grid tem colunas corretas para o tamanho informado', () => {
-    const { container } = render(<MazeMap size={8} />)
-    const grid = container.querySelector('div > div > div:last-child')
-    expect(grid).toHaveStyle('grid-template-columns: repeat(8, 1fr)')
+    render(<MazeMap size={8} />)
+    expect(screen.getByRole('grid')).toHaveStyle('grid-template-columns: repeat(8, 1fr)')
   })
 
   it('exibe mensagem de aguardando dados', () => {
     render(<MazeMap />)
-    expect(screen.getByText(/aguardando dados de mapeamento/i)).toBeInTheDocument()
+    expect(screen.getByText(/aguardando dados de telemetria/i)).toBeInTheDocument()
   })
 })

--- a/src/frontend/src/hooks/useTelemetry.js
+++ b/src/frontend/src/hooks/useTelemetry.js
@@ -1,0 +1,143 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ehChegada } from '../utils/maze';
+
+// URL do WebSocket de telemetria. Em integração/produção, aponte para a API
+// FastAPI definindo VITE_WS_URL (ex.: ws://localhost:8000/ws/telemetria).
+const WS_URL =
+  import.meta.env?.VITE_WS_URL ??
+  `ws://${typeof window !== 'undefined' ? window.location.hostname : 'localhost'}:8000/ws/telemetria`;
+
+const RECONEXAO_MS = 2000;
+
+export const STATUS = {
+  conectando: 'conectando',
+  conectado: 'conectado',
+  desconectado: 'desconectado',
+  indisponivel: 'indisponivel', // ambiente sem WebSocket (ex.: testes em jsdom)
+};
+
+function formatarTempo(segundos) {
+  const s = Math.max(0, Math.floor(segundos));
+  const hh = String(Math.floor(s / 3600)).padStart(2, '0');
+  const mm = String(Math.floor((s % 3600) / 60)).padStart(2, '0');
+  const ss = String(s % 60).padStart(2, '0');
+  return `${hh}:${mm}:${ss}`;
+}
+
+// Consome o WebSocket /ws/telemetria como observador passivo: apenas recebe os
+// eventos transmitidos pelo backend e deriva as métricas exibidas no painel.
+// `size` é o tamanho do labirinto escolhido na UI e afeta apenas o cálculo de
+// "desafio cumprido" (não reabre a conexão).
+export default function useTelemetry(size) {
+  // O estado inicial já reflete a ausência de WebSocket (ex.: jsdom nos testes),
+  // evitando um setState síncrono dentro do efeito.
+  const [status, setStatus] = useState(() =>
+    typeof WebSocket === 'undefined' ? STATUS.indisponivel : STATUS.conectando
+  );
+  const [eventos, setEventos] = useState([]);
+
+  const wsRef = useRef(null);
+  const reconexaoRef = useRef(null);
+  const montadoRef = useRef(true);
+
+  useEffect(() => {
+    montadoRef.current = true;
+
+    if (typeof WebSocket === 'undefined') {
+      return () => {
+        montadoRef.current = false;
+      };
+    }
+
+    function agendarReconexao() {
+      if (!montadoRef.current) return;
+      clearTimeout(reconexaoRef.current);
+      reconexaoRef.current = setTimeout(() => {
+        setStatus(STATUS.conectando);
+        conectar();
+      }, RECONEXAO_MS);
+    }
+
+    function conectar() {
+      if (!montadoRef.current) return;
+
+      let ws;
+      try {
+        ws = new WebSocket(WS_URL);
+      } catch {
+        agendarReconexao();
+        return;
+      }
+      wsRef.current = ws;
+
+      ws.onopen = () => setStatus(STATUS.conectado);
+
+      ws.onmessage = (ev) => {
+        try {
+          const dado = JSON.parse(ev.data);
+          // Ignora mensagens de erro do backend ({ erro, ... }); só aceita eventos
+          // de telemetria com posição válida.
+          if (typeof dado.posicao_x === 'number' && typeof dado.posicao_y === 'number') {
+            setEventos((prev) => [...prev, dado]);
+          }
+        } catch {
+          // mensagem não-JSON: ignora
+        }
+      };
+
+      ws.onerror = () => ws.close();
+
+      ws.onclose = () => {
+        if (!montadoRef.current) return;
+        setStatus(STATUS.desconectado);
+        agendarReconexao();
+      };
+    }
+
+    conectar();
+
+    return () => {
+      montadoRef.current = false;
+      clearTimeout(reconexaoRef.current);
+      const ws = wsRef.current;
+      if (ws) {
+        ws.onclose = null; // evita disparar reconexão durante o unmount
+        ws.onerror = null;
+        ws.close();
+      }
+    };
+  }, []);
+
+  const derivado = useMemo(() => {
+    const trajeto = eventos.map((e) => ({ x: e.posicao_x, y: e.posicao_y }));
+    const ultimo = eventos[eventos.length - 1] ?? null;
+
+    const velocidades = eventos
+      .map((e) => e.velocidade)
+      .filter((v) => typeof v === 'number');
+    const velocidadeMedia = velocidades.length
+      ? velocidades.reduce((a, b) => a + b, 0) / velocidades.length
+      : null;
+
+    let segundos = 0;
+    if (eventos.length >= 2) {
+      const inicio = Date.parse(eventos[0].timestamp);
+      const fim = Date.parse(ultimo.timestamp);
+      if (!Number.isNaN(inicio) && !Number.isNaN(fim)) {
+        segundos = (fim - inicio) / 1000;
+      }
+    }
+
+    return {
+      trajeto,
+      posicaoAtual: ultimo ? { x: ultimo.posicao_x, y: ultimo.posicao_y } : null,
+      bateria: ultimo ? ultimo.nivel_bateria : null,
+      velocidadeMedia,
+      tempo: formatarTempo(segundos),
+      desafioCumprido: trajeto.some((p) => ehChegada(p.x, p.y, size)),
+      totalEventos: eventos.length,
+    };
+  }, [eventos, size]);
+
+  return { status, ...derivado };
+}

--- a/src/frontend/src/pages/Telemetry.jsx
+++ b/src/frontend/src/pages/Telemetry.jsx
@@ -1,48 +1,117 @@
+import { useState } from 'react';
 import MazeMap from '../components/MazeMap';
+import useTelemetry, { STATUS } from '../hooks/useTelemetry';
+
+const TAMANHOS = [4, 8, 16];
+
+const STATUS_INFO = {
+  [STATUS.conectando]: { texto: 'Conectando…', cor: '#b58900' },
+  [STATUS.conectado]: { texto: 'Conectado', cor: '#2e7d32' },
+  [STATUS.desconectado]: { texto: 'Desconectado', cor: '#c62828' },
+  [STATUS.indisponivel]: { texto: 'WebSocket indisponível', cor: '#888' },
+};
 
 export default function Telemetry() {
+  const [size, setSize] = useState(4);
+  const t = useTelemetry(size);
+  const statusInfo = STATUS_INFO[t.status] ?? STATUS_INFO[STATUS.desconectado];
+
   return (
     <div>
-      <h1>Painel de Controle</h1>
+      <div style={styles.titleRow}>
+        <h1>Painel de Controle</h1>
+        <span style={{ ...styles.statusPill, backgroundColor: statusInfo.cor }}>
+          ● {statusInfo.texto}
+        </span>
+      </div>
+
+      <div style={styles.controls}>
+        <label htmlFor="tamanho-labirinto">Tamanho do labirinto: </label>
+        <select
+          id="tamanho-labirinto"
+          value={size}
+          onChange={(e) => setSize(Number(e.target.value))}
+        >
+          {TAMANHOS.map((n) => (
+            <option key={n} value={n}>
+              {n}x{n}
+            </option>
+          ))}
+        </select>
+      </div>
+
       <div style={styles.dashboard}>
-        
-        {/* Painel de Dados */}
+        {/* Painel de métricas */}
         <div style={styles.dataPanel}>
           <h3>Status da Corrida</h3>
-          <div style={styles.statBox}><strong>Velocidade Média:</strong> -- m/s</div>
-          <div style={styles.statBox}><strong>Tempo:</strong> 00:00:00</div>
-          <div style={styles.statBox}><strong>Bateria:</strong> 100% 🔋</div>
-          <div style={styles.statBox}><strong>Status:</strong> Explorando...</div>
+          <div style={styles.statBox}>
+            <strong>Velocidade Média:</strong>{' '}
+            {t.velocidadeMedia != null ? `${t.velocidadeMedia.toFixed(2)} m/s` : '-- m/s'}
+          </div>
+          <div style={styles.statBox}>
+            <strong>Tempo:</strong> {t.tempo}
+          </div>
+          <div style={styles.statBox}>
+            <strong>Bateria:</strong> {t.bateria != null ? `${Math.round(t.bateria)}%` : '--%'} 🔋
+          </div>
+          <div style={styles.statBox}>
+            <strong>Desafio Cumprido:</strong>{' '}
+            <span style={{ color: t.desafioCumprido ? '#2e7d32' : '#c62828', fontWeight: 'bold' }}>
+              {t.desafioCumprido ? 'Sim' : 'Não'}
+            </span>
+          </div>
+          <div style={styles.statBox}>
+            <strong>Posição:</strong>{' '}
+            {t.posicaoAtual ? `(${t.posicaoAtual.x}, ${t.posicaoAtual.y})` : '--'}
+          </div>
         </div>
 
-        {/* Componente do Mapa */}
+        {/* Mapa do labirinto com o trajeto em tempo real */}
         <div style={styles.mapPanel}>
-          <MazeMap size={4} />
+          <MazeMap size={size} trajeto={t.trajeto} posicaoAtual={t.posicaoAtual} />
         </div>
-
       </div>
     </div>
   );
 }
 
 const styles = {
+  titleRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '1rem',
+    flexWrap: 'wrap',
+  },
+  statusPill: {
+    color: 'white',
+    fontSize: '13px',
+    fontWeight: 'bold',
+    padding: '4px 10px',
+    borderRadius: '12px',
+  },
+  controls: {
+    marginTop: '0.5rem',
+  },
   dashboard: {
     display: 'flex',
     gap: '2rem',
-    marginTop: '1rem'
+    marginTop: '1rem',
+    flexWrap: 'wrap',
   },
   dataPanel: {
     flex: 1,
+    minWidth: '240px',
     padding: '1rem',
     backgroundColor: '#f4f4f4',
-    borderRadius: '8px'
+    borderRadius: '8px',
   },
   mapPanel: {
-    flex: 2
+    flex: 2,
+    minWidth: '280px',
   },
   statBox: {
     padding: '10px',
     borderBottom: '1px solid #ddd',
-    fontSize: '16px'
-  }
+    fontSize: '16px',
+  },
 };

--- a/src/frontend/src/pages/Telemetry.test.jsx
+++ b/src/frontend/src/pages/Telemetry.test.jsx
@@ -1,0 +1,81 @@
+// Testes da tela de telemetria ao vivo (issue #19).
+//
+// Em jsdom não existe WebSocket nativo. No primeiro teste deixamos esse estado
+// como está (o hook entra em "indisponível" e a tela ainda monta). No segundo,
+// injetamos um WebSocket falso para simular exatamente o broadcast do backend
+// (formato TelemetriaOut) e conferir que as métricas, o trajeto e o indicador
+// de desafio reagem aos dados. Os testes de unidade mais amplos da página são a
+// Tarefa T10 (#127); aqui validamos o núcleo entregue por esta issue.
+import { render, screen, act } from '@testing-library/react'
+import Telemetry from './Telemetry'
+
+describe('Telemetry', () => {
+  it('renderiza o painel de métricas e o seletor de tamanho', () => {
+    render(<Telemetry />)
+
+    expect(screen.getByRole('heading', { name: 'Painel de Controle' })).toBeInTheDocument()
+    expect(screen.getByText('Velocidade Média:')).toBeInTheDocument()
+    expect(screen.getByText('Tempo:')).toBeInTheDocument()
+    expect(screen.getByText('Bateria:')).toBeInTheDocument()
+    expect(screen.getByText('Desafio Cumprido:')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Tamanho do labirinto/i)).toBeInTheDocument()
+  })
+
+  it('mostra o mapa 4x4 por padrão e sem dados de trajeto', () => {
+    render(<Telemetry />)
+
+    expect(screen.getByRole('heading', { name: /Mapa do Labirinto \(4x4\)/ })).toBeInTheDocument()
+    expect(screen.getByText(/Aguardando dados de telemetria/i)).toBeInTheDocument()
+    expect(screen.getByText('Não')).toBeInTheDocument()
+  })
+
+  it('atualiza métricas e marca o desafio ao receber telemetria via WebSocket', async () => {
+    // WebSocket falso: registra a instância criada e expõe os handlers que o
+    // hook atribui (onopen/onmessage), para dispararmos eventos manualmente.
+    class FakeWebSocket {
+      constructor(url) {
+        this.url = url
+        FakeWebSocket.instances.push(this)
+      }
+      close() {}
+    }
+    FakeWebSocket.instances = []
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+
+    try {
+      render(<Telemetry />)
+      const ws = FakeWebSocket.instances[0]
+      expect(ws).toBeTruthy()
+      expect(ws.url).toMatch(/\/ws\/telemetria$/)
+
+      await act(async () => {
+        ws.onopen()
+      })
+      expect(screen.getByText(/Conectado/)).toBeInTheDocument()
+
+      // Mesmo formato (TelemetriaOut) que o backend transmite no broadcast.
+      await act(async () => {
+        ws.onmessage({
+          data: JSON.stringify({
+            id: 1, corrida_id: 1, posicao_x: 0, posicao_y: 0,
+            nivel_bateria: 100, velocidade: 0.4, timestamp: '2026-05-10T12:00:00Z',
+          }),
+        })
+        // (1,1) é célula central do 4x4 -> desafio cumprido.
+        ws.onmessage({
+          data: JSON.stringify({
+            id: 2, corrida_id: 1, posicao_x: 1, posicao_y: 1,
+            nivel_bateria: 90, velocidade: 0.6, timestamp: '2026-05-10T12:00:02Z',
+          }),
+        })
+      })
+
+      expect(screen.getByText(/0\.50 m\/s/)).toBeInTheDocument() // média de 0.4 e 0.6
+      expect(screen.getByText(/90%/)).toBeInTheDocument() // bateria do último evento
+      expect(screen.getByText(/\(1, 1\)/)).toBeInTheDocument() // posição atual
+      expect(screen.getByText('Sim')).toBeInTheDocument() // desafio cumprido
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})

--- a/src/frontend/src/utils/maze.js
+++ b/src/frontend/src/utils/maze.js
@@ -1,0 +1,9 @@
+// Geometria do labirinto do micromouse.
+// O objetivo do desafio é alcançar a "chegada", que é o bloco 2x2 no centro
+// do labirinto NxN (convenção clássica do Micromouse). Funciona para 4x4,
+// 8x8 e 16x16 porque o centro de um N par são as células [N/2-1, N/2].
+export function ehChegada(x, y, size) {
+  const inferior = size / 2 - 1;
+  const superior = size / 2;
+  return x >= inferior && x <= superior && y >= inferior && y <= superior;
+}


### PR DESCRIPTION
## O que foi feito

Implementa a tela de **telemetria ao vivo** (#19) e os testes **E2E de
robustez de reconexão** (#132).

### #19 — Tela de telemetria ao vivo
- Hook `useTelemetry` consome o WebSocket `/ws/telemetria` como observador
  passivo (não envia nada — apenas recebe o broadcast do backend).
- `MazeMap` desenha o grid NxN (4x4/8x8/16x16) com trajeto, posição atual e
  célula de chegada (bloco 2x2 central), com legenda.
- Painel de métricas: bateria, velocidade média, tempo decorrido e indicador
  de desafio cumprido (Sim/Não).
- Indicador de status da conexão + reconexão automática.
- Teste de unidade da página com WebSocket mockado.

### #132 — E2E de reconexão (T15)
- Simula queda do WebSocket, valida indicador de conexão perdida, reconexão
  automática, conexão restaurada e retomada da atualização dos dados.
- Automatiza o roteiro manual da #24.

## Como testar
```bash
cd src/frontend
npm install
npm test          # unit (Vitest) — 5/5
npx playwright install chromium
npm run e2e       # E2E (Playwright) — 3/3
