### PR TITLE
Feature/histórico com filtros

### DIFF
--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -1,8 +1,18 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from app.routes.health import router as health_router
 from app.routes.telemetria import router as telemetria_router
+from app.routes.corridas import router as corridas_router
 
 app = FastAPI(title="Micromouse Telemetria API")
 
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 app.include_router(health_router)
 app.include_router(telemetria_router)
+app.include_router(corridas_router)

--- a/src/backend/app/routes/corridas.py
+++ b/src/backend/app/routes/corridas.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session, joinedload
+from typing import Optional, List
+
+from app.database import get_db
+from app.models.models import Corrida, Labirinto, DimensaoLabirinto
+from app.schemas.corrida import CorridaResponse
+
+router = APIRouter(prefix="/corridas", tags=["corridas"])
+
+
+@router.get("", response_model=List[CorridaResponse])
+def listar_corridas(
+    tamanho: Optional[DimensaoLabirinto] = Query(
+        default=None,
+        description="Filtrar por dimensão do labirinto: 4x4, 8x8 ou 16x16",
+    ),
+    db: Session = Depends(get_db),
+):
+    """
+    Retorna o histórico de corridas.
+    Use o parâmetro `tamanho` para filtrar por dimensão do labirinto (ex: ?tamanho=4x4).
+    Sem filtro, retorna todas as corridas.
+    """
+    query = db.query(Corrida).options(joinedload(Corrida.labirinto))
+
+    if tamanho is not None:
+        query = query.join(Labirinto).filter(Labirinto.dimensao == tamanho)
+
+    corridas = query.order_by(Corrida.data.desc()).all()
+
+    return [
+        CorridaResponse(
+            id=c.id,
+            labirinto_id=c.labirinto_id,
+            tamanho=c.labirinto.dimensao.value,
+            data=c.data,
+            duracao=c.duracao,
+            velocidade_media=c.velocidade_media,
+            resultado=c.resultado,
+        )
+        for c in corridas
+    ]

--- a/src/backend/app/schemas/corrida.py
+++ b/src/backend/app/schemas/corrida.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, ConfigDict
+from datetime import datetime
+from typing import Optional
+from app.models.models import ResultadoCorrida
+
+
+class CorridaResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    
+    id: int
+    labirinto_id: int
+    tamanho: str  # ex: "4x4", "8x8", "16x16"
+    data: Optional[datetime]
+    duracao: Optional[float]
+    velocidade_media: Optional[float]
+    resultado: ResultadoCorrida

--- a/src/frontend/src/hooks/useHistory.js
+++ b/src/frontend/src/hooks/useHistory.js
@@ -1,0 +1,45 @@
+import { useEffect, useState, useCallback } from 'react';
+
+// URL base da API REST. Configure VITE_API_URL no .env para apontar ao backend.
+// Ex.: VITE_API_URL=http://localhost:8000
+const API_URL =
+  import.meta.env?.VITE_API_URL ??
+  `http://${typeof window !== 'undefined' ? window.location.hostname : 'localhost'}:8000`;
+
+// Busca o histórico de corridas no endpoint GET /corridas.
+// `tamanho` pode ser '4x4', '8x8', '16x16' ou 'todos' (sem filtro).
+export default function useHistory(tamanho) {
+  const [corridas, setCorridas] = useState([]);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState(null);
+
+  const buscar = useCallback(async () => {
+    setCarregando(true);
+    setErro(null);
+
+    try {
+      const params = new URLSearchParams();
+      if (tamanho !== 'todos') params.set('tamanho', tamanho);
+
+      const resposta = await fetch(`${API_URL}/corridas?${params.toString()}`);
+
+      if (!resposta.ok) {
+        throw new Error(`Erro ${resposta.status}: ${resposta.statusText}`);
+      }
+
+      const dados = await resposta.json();
+      setCorridas(dados);
+    } catch (err) {
+      setErro(err.message ?? 'Erro desconhecido ao carregar histórico.');
+      setCorridas([]);
+    } finally {
+      setCarregando(false);
+    }
+  }, [tamanho]);
+
+  useEffect(() => {
+    buscar();
+  }, [buscar]);
+
+  return { corridas, carregando, erro, recarregar: buscar };
+}

--- a/src/frontend/src/pages/History.jsx
+++ b/src/frontend/src/pages/History.jsx
@@ -1,35 +1,107 @@
+import { useState } from 'react';
+import useHistory from '../hooks/useHistory';
+
+const TAMANHOS = ['todos', '4x4', '8x8', '16x16'];
+
+function formatarTempo(segundos) {
+  if (segundos == null || isNaN(segundos)) return '—';
+  const s = Math.max(0, Math.floor(segundos));
+  const hh = String(Math.floor(s / 3600)).padStart(2, '0');
+  const mm = String(Math.floor((s % 3600) / 60)).padStart(2, '0');
+  const ss = String(s % 60).padStart(2, '0');
+  return `${hh}:${mm}:${ss}`;
+}
+
+function formatarResultado(resultado) {
+  const mapa = {
+    concluida: '✅ Concluída',
+    falha: '❌ Falha',
+    em_andamento: '⏳ Em andamento',
+  };
+  return mapa[resultado] ?? resultado;
+}
+
 export default function History() {
+  const [filtro, setFiltro] = useState('todos');
+  const { corridas, carregando, erro, recarregar } = useHistory(filtro);
+
   return (
     <div>
       <h1>Histórico de Corridas</h1>
-      <div style={{ marginBottom: '1rem' }}>
-        <label>Filtrar por tamanho: </label>
-        <select>
-          <option value="todos">Todos</option>
-          <option value="4x4">4x4</option>
-          <option value="8x8">8x8</option>
-          <option value="16x16">16x16</option>
+
+      {/* Filtro */}
+      <div style={{ marginBottom: '1rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <label htmlFor="filtro-tamanho">Filtrar por tamanho: </label>
+        <select
+          id="filtro-tamanho"
+          value={filtro}
+          onChange={(e) => setFiltro(e.target.value)}
+          disabled={carregando}
+        >
+          {TAMANHOS.map((t) => (
+            <option key={t} value={t}>
+              {t === 'todos' ? 'Todos' : t}
+            </option>
+          ))}
         </select>
+        <button onClick={recarregar} disabled={carregando} title="Atualizar">
+          {carregando ? '⏳' : '🔄'}
+        </button>
       </div>
 
-      <table style={styles.table}>
-        <thead>
-          <tr style={styles.headerRow}>
-            <th>ID da Corrida</th>
-            <th>Tamanho</th>
-            <th>Tempo Total</th>
-            <th>Desafio Cumprido?</th>
-            <th>Ações</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td colSpan="5" style={{ textAlign: 'center', padding: '1rem' }}>
-              Nenhum dado recebido do banco (SQLite) ainda.
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      {/* Estado: erro */}
+      {erro && (
+        <div style={{ textAlign: 'center', padding: '2rem', color: '#f87171' }}>
+          <p>⚠️ {erro}</p>
+          <button onClick={recarregar}>Tentar novamente</button>
+        </div>
+      )}
+
+      {/* Estado: carregando */}
+      {carregando && !erro && (
+        <p style={{ textAlign: 'center', padding: '1rem' }}>Carregando corridas...</p>
+      )}
+
+      {/* Estado: vazio */}
+      {!carregando && !erro && corridas.length === 0 && (
+        <p style={{ textAlign: 'center', padding: '2rem', color: '#94a3b8' }}>
+          🏁{' '}
+          {filtro === 'todos'
+            ? 'Nenhuma corrida registrada ainda.'
+            : `Nenhuma corrida encontrada para labirintos ${filtro}.`}
+        </p>
+      )}
+
+      {/* Estado: dados */}
+      {!carregando && !erro && corridas.length > 0 && (
+        <>
+          <table style={styles.table}>
+            <thead>
+              <tr style={styles.headerRow}>
+                <th>ID da Corrida</th>
+                <th>Tamanho</th>
+                <th>Duração</th>
+                <th>Resultado</th>
+              </tr>
+            </thead>
+            <tbody>
+              {corridas.map((corrida, idx) => (
+                <tr key={corrida.id ?? idx}>
+                  <td style={styles.td}>{corrida.id ?? '—'}</td>
+                  <td style={styles.td}>{corrida.tamanho ?? '—'}</td>
+                  <td style={styles.td}>{formatarTempo(corrida.duracao)}</td>
+                  <td style={styles.td}>{formatarResultado(corrida.resultado)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p style={{ marginTop: '0.5rem', fontSize: '0.8rem', color: '#64748b', textAlign: 'right' }}>
+            {corridas.length} corrida{corridas.length !== 1 ? 's' : ''} encontrada
+            {corridas.length !== 1 ? 's' : ''}
+            {filtro !== 'todos' ? ` para ${filtro}` : ''}.
+          </p>
+        </>
+      )}
     </div>
   );
 }
@@ -38,11 +110,15 @@ const styles = {
   table: {
     width: '100%',
     borderCollapse: 'collapse',
-    marginTop: '1rem'
+    marginTop: '1rem',
   },
   headerRow: {
     backgroundColor: '#282c34',
     color: 'white',
     textAlign: 'left',
-  }
+  },
+  td: {
+    padding: '0.7rem 1rem',
+    borderBottom: '1px solid #2d3748',
+  },
 };


### PR DESCRIPTION
## 1. Descrição
Implementação da tela de histórico de corridas do Micromouse, permitindo visualizar e filtrar corridas passadas por tamanho de labirinto (4x4, 8x8, 16x16). Inclui tanto o endpoint backend quanto o componente frontend

## 2. Relacionado à Issue
Closes #20 

## 3. Alterações Realizadas
- Criação do schema `CorridaResponse` em `app/schemas/corridas.py`
- Criação do endpoint `GET /corridas` com filtro por tamanho em `app/routes/corridas.py`
- Registro da rota de corridas e configuração de CORS em `app/main.py`
- Criação do hook `useHistory` para buscar corridas da API em `src/hooks/useHistory.js`
- Implementação da tela de histórico com dropdown de filtro, tabela de corridas e tratamento de estados (carregando, erro, vazio) em `src/pages/History.jsx`

## 4. Tipo de Mudança
[Marque com um 'x' dentro dos colchetes a opção que representa o que você fez]
- [x] **feature/** (Nova funcionalidade de software)
- [ ] **fix/** (Correção de bug/problema)
- [ ] **docs/** (Documentação no relatório ou no repositório)
- [ ] **hw/** (Alterações em hardware - esquemáticos, PCB)
- [ ] **mec/** (Alterações em arquivos mecânicos - CAD)
- [ ] **refactor/** (Refatoração de código sem mudança de comportamento)

## 5. Como Testar / Validar
- Passo 1: Na pasta `src/backend`, ative o venv e rode `uvicorn app.main:app --reload`
- Passo 2: Na pasta `src/frontend`, rode `npm run dev`
- Passo 3: Acesse `http://localhost:5173/historico`
- Passo 4: Verifique que a tabela exibe as corridas do banco
- Passo 5: Troque o filtro de tamanho e confirme que a tabela atualiza
- Passo 6: Também é possível testar o endpoint diretamente em `http://localhost:8000/docs` → `GET /corridas`
- Resultado esperado: tabela com corridas filtráveis, mensagem de estado vazio quando não há dados, e mensagem de erro com botão de retry em caso de falha na API