### PR TITLE
docs(relatorio): documenta suíte de testes do encerramento de corrida (7.5)

### DIFF
--- a/docs/relatorio/editaveis/09_resultados.tex
+++ b/docs/relatorio/editaveis/09_resultados.tex
@@ -318,8 +318,9 @@ de cobertura correspondentes constam do Apêndice~\ref{apendice_evidencias_teste
         \textbf{Camada} & \textbf{Ferramentas} & \textbf{Principais suítes} &
         \textbf{Testes} & \textbf{Cobertura} \\ \hline
         \textit{Backend} & \texttt{pytest}, \texttt{pytest-cov} &
-        telemetria (POST e WebSocket), \textit{models} e \textit{schemas},
-        histórico/consulta e \textit{health} & 74 & $98\%$ \\ \hline
+        telemetria (POST e WebSocket), encerramento de corrida (gatilho,
+        agregados e transição de \textit{resultado}), \textit{models} e
+        \textit{schemas}, histórico/consulta e \textit{health} & 83 & $98\%$ \\ \hline
         \textit{Frontend} & \texttt{Vitest}, \textit{Testing Library} &
         páginas \textit{Telemetry} e \textit{History}, componentes \textit{Layout} e
         \textit{MazeMap}, \textit{hooks} e roteamento & 37 & $93\%$ \\ \hline


### PR DESCRIPTION
## O que foi feito

Documenta a suíte de testes do encerramento de corrida (`test_encerramento.py`, entregue no #170) na seção 7.5 (Testes de software) do relatório, conforme as instruções registradas na #145.

- Adiciona a suíte à Tabela de suítes de testes unitários e de integração (`tab:suites_unit`), descrevendo o que cobre: gatilho/endpoint de encerramento, cálculo de `duracao` e `velocidade_media` e transição de `resultado`.
- Atualiza a contagem de testes do backend de 74 para 83 (cobertura de 98% mantida, acima do mínimo de 70%).

## Observações

- Atende ao item de documentação da #145 (os demais critérios da issue já foram cobertos pelos testes do #170).
- Sem alteração de código; apenas o arquivo `docs/relatorio/editaveis/09_resultados.tex`.
- Relatório recompila sem erros (a única referência indefinida, `fig:arquitetura_sistema`, é pré-existente e alheia a esta mudança).

Closes #145

Relacionado: #170, #16.

