### PR TITLE
feat: configuração de rede (CORS e URLs por variável de ambiente) (#146)

### DIFF
--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -1,0 +1,13 @@
+# Exemplo de variáveis de ambiente do backend.
+# Copie para .env e ajuste conforme o ambiente. Nenhuma variável é obrigatória:
+# todas têm um default local. O .env real não é versionado (veja .gitignore).
+
+# URL de conexão do banco de dados.
+# Default: SQLite local (arquivo micromouse.db).
+# DATABASE_URL=sqlite:///./micromouse.db
+
+# Origens permitidas para CORS, separadas por vírgula.
+# Default cobre o frontend local (Vite em :5173). Para acessar o backend a
+# partir de outra máquina na mesma rede, inclua o endereço do frontend, ex.:
+# CORS_ORIGINS=http://localhost:5173,http://192.168.0.10:5173
+# CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173

--- a/src/backend/.gitignore
+++ b/src/backend/.gitignore
@@ -4,3 +4,8 @@ htmlcov/
 .coverage
 .coverage.*
 coverage.xml
+
+# Variáveis de ambiente (mantém apenas o exemplo versionado)
+.env
+.env.*
+!.env.example

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -110,6 +110,38 @@ http://localhost:8000
 
 ---
 
+## 🌐 Configuração de rede (acesso por outra máquina)
+
+Por padrão o backend só aceita requisições do frontend local
+(`http://localhost:5173`). Para que o ESP32 ou outro computador na mesma rede
+acessem a API, há dois ajustes:
+
+**1. Liberar a origem do frontend no CORS.** As origens são lidas da variável
+de ambiente `CORS_ORIGINS` (lista separada por vírgula). Copie o exemplo e
+ajuste:
+
+```bash
+cp .env.example .env
+# edite .env e inclua o endereço do frontend pela rede, ex.:
+# CORS_ORIGINS=http://localhost:5173,http://192.168.0.10:5173
+```
+
+O `.env` é carregado automaticamente na inicialização (via `python-dotenv`) e
+**não** é versionado. Sem ele, vale o default local.
+
+**2. Expor o servidor na rede.** O `uvicorn` sobe em `127.0.0.1` por padrão
+(inacessível de fora). Use `--host 0.0.0.0` para escutar em todas as interfaces:
+
+```bash
+uvicorn app.main:app --reload --host 0.0.0.0
+```
+
+Descubra o IP da máquina (ex.: `ipconfig getifaddr en0` no macOS,
+`hostname -I` no Linux) e acesse de outro dispositivo por
+`http://<IP-da-máquina>:8000`.
+
+---
+
 ## ✅ Testes automatizados (pytest + cobertura)
 
 > 🤖 **Precisa do robô / ESP32 / sensores para rodar os testes? NÃO.**

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -1,14 +1,34 @@
+import os
+
+from dotenv import load_dotenv
+
+# Carrega variáveis de um arquivo .env (se existir) antes de qualquer import que
+# leia configuração de ambiente. Em produção/CI as variáveis costumam vir do
+# próprio ambiente, e o .env é apenas uma conveniência para desenvolvimento.
+load_dotenv()
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app.routes.health import router as health_router
 from app.routes.telemetria import router as telemetria_router
 from app.routes.corridas import router as corridas_router
 
+# Origens permitidas para CORS, configuráveis por ambiente (lista separada por
+# vírgula). O default cobre o frontend local (Vite em :5173); para acessar o
+# backend pela rede, inclua o endereço do frontend em CORS_ORIGINS, por exemplo:
+# CORS_ORIGINS=http://localhost:5173,http://192.168.0.10:5173
+CORS_ORIGINS_PADRAO = "http://localhost:5173,http://127.0.0.1:5173"
+cors_origins = [
+    origem.strip()
+    for origem in os.getenv("CORS_ORIGINS", CORS_ORIGINS_PADRAO).split(",")
+    if origem.strip()
+]
+
 app = FastAPI(title="Micromouse Telemetria API")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=cors_origins,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -1,0 +1,12 @@
+# Exemplo de variáveis de ambiente do frontend (Vite).
+# Copie para .env e ajuste conforme o ambiente. Nenhuma é obrigatória: sem elas,
+# a aplicação assume o backend no mesmo host, na porta 8000. O Vite só expõe
+# variáveis com o prefixo VITE_. O .env real não é versionado (veja .gitignore).
+
+# URL base da API REST do backend.
+# Default: http://<host-atual>:8000
+# VITE_API_URL=http://192.168.0.10:8000
+
+# URL do WebSocket de telemetria do backend.
+# Default: ws://<host-atual>:8000/ws/telemetria
+# VITE_WS_URL=ws://192.168.0.10:8000/ws/telemetria

--- a/src/frontend/.gitignore
+++ b/src/frontend/.gitignore
@@ -12,6 +12,11 @@ dist
 dist-ssr
 *.local
 
+# Variáveis de ambiente (mantém apenas o exemplo versionado)
+.env
+.env.*
+!.env.example
+
 # Artefatos de testes
 coverage
 test-results

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -15,6 +15,33 @@ The React Compiler is not enabled on this template because of its impact on dev 
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
 
+## 🌐 Configuração de rede (backend por IP)
+
+As URLs do backend (API REST e WebSocket de telemetria) são configuráveis por
+variável de ambiente. Sem configuração, o frontend assume o backend **no mesmo
+host** em que a página foi aberta, na porta `8000` — ou seja, o acesso pela rede
+já funciona automaticamente ao abrir o site por `http://<IP-da-máquina>:5173`.
+
+Para fixar um backend específico, copie o exemplo e ajuste:
+
+```bash
+cp .env.example .env
+# edite .env, ex.:
+# VITE_API_URL=http://192.168.0.10:8000
+# VITE_WS_URL=ws://192.168.0.10:8000/ws/telemetria
+```
+
+O Vite só expõe variáveis com prefixo `VITE_`. O `.env` real **não** é
+versionado. Para servir a aplicação na rede (acessível de outro dispositivo),
+rode o Vite com `--host`:
+
+```bash
+npm run dev -- --host
+```
+
+> Lembre-se de liberar a origem do frontend no `CORS_ORIGINS` do backend
+> (veja o README do backend).
+
 ## ✅ Testes automatizados (Vitest + Testing Library)
 
 > 🤖 **Precisa do robô / ESP32 / backend rodando para os testes? NÃO.**


### PR DESCRIPTION
## O que foi feito

Torna a comunicação entre frontend, backend e ESP32 configurável por rede, sem hardcode de `localhost`. Atende à #146.

### Backend
- Origens de CORS lidas da variável `CORS_ORIGINS` (lista separada por vírgula), com default local (`localhost`/`127.0.0.1:5173`). Antes estava cravado em `http://localhost:5173`.
- `load_dotenv` na inicialização para carregar um `.env` opcional (o `python-dotenv` já era dependência).
- `.env.example` documentando `DATABASE_URL` e `CORS_ORIGINS`; `.env` real ignorado no git.

### Frontend
- `.env.example` documentando `VITE_API_URL` e `VITE_WS_URL` (que os hooks `useHistory`/`useTelemetry` já consomem, com fallback por `window.location.hostname`); `.env` real ignorado no git.

### Documentação
- README do backend e do frontend com a seção de configuração de rede (CORS, `uvicorn --host 0.0.0.0`, `npm run dev -- --host`).

## Critério ainda pendente

- [x] **Validar o acesso do frontend ao backend a partir de outra máquina/IP na mesma rede** — validado em 16/06 com cliente Windows (192.168.1.49) acessando o backend no macOS (192.168.1.8): histórico carregou via GET /corridas sem erro de CORS e WebSocket conectou (101).

## Como testar localmente

```bash
cd src/backend && source venv/bin/activate
CORS_ORIGINS="http://localhost:5173,http://192.168.0.10:5173" python -c "import app.main as m; print(m.cors_origins)"
pytest   # 83 passam
```

Closes #146

