### PR TITLE
Refinamento de UI (telemetria e historico) #25

### DIFF
--- a/src/frontend/src/components/Layout.jsx
+++ b/src/frontend/src/components/Layout.jsx
@@ -5,57 +5,27 @@ export default function Layout() {
 
   return (
     <div>
-      <header style={styles.header}>
+      <header className="layout-header">
         <h2>Micromouse Telemetria</h2>
-        <nav style={styles.nav}>
+        <nav className="nav-links">
           <Link 
             to="/" 
-            style={location.pathname === '/' ? styles.activeLink : styles.link}
+            className={`nav-link ${location.pathname === '/' ? 'active' : ''}`}
           >
             Telemetria ao Vivo
           </Link>
           <Link 
             to="/historico" 
-            style={location.pathname === '/historico' ? styles.activeLink : styles.link}
+            className={`nav-link ${location.pathname === '/historico' ? 'active' : ''}`}
           >
             Histórico
           </Link>
         </nav>
       </header>
       
-      <main style={styles.main}>
-        {/* O Outlet renderiza a página atual baseada na rota */}
+      <main className="main-content">
         <Outlet /> 
       </main>
     </div>
   );
 }
-
-const styles = {
-  header: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: '1rem 2rem',
-    backgroundColor: '#282c34',
-    color: 'white'
-  },
-  nav: {
-    display: 'flex',
-    gap: '20px'
-  },
-  link: {
-    color: '#ccc',
-    textDecoration: 'none',
-    fontWeight: 'bold'
-  },
-  activeLink: {
-    color: '#61dafb',
-    textDecoration: 'none',
-    fontWeight: 'bold',
-    borderBottom: '2px solid #61dafb'
-  },
-  main: {
-    padding: '2rem'
-  }
-};

--- a/src/frontend/src/components/MazeMap.jsx
+++ b/src/frontend/src/components/MazeMap.jsx
@@ -1,10 +1,10 @@
 import { ehChegada } from '../utils/maze';
 
 const CORES = {
-  posicao: '#1565c0', // posição atual do robô
-  chegada: '#c8e6c9', // bloco 2x2 central (objetivo)
-  inicio: '#ffe0b2', // primeira célula do trajeto
-  trajeto: '#bbdefb', // células já visitadas
+  posicao: '#2563eb', // var(--primary)
+  chegada: '#10b981', // var(--success)
+  inicio: '#f59e0b',  // var(--warning)
+  trajeto: '#bfdbfe', 
   vazia: 'white',
 };
 
@@ -25,10 +25,12 @@ export default function MazeMap({ size = 4, trajeto = [], posicaoAtual = null })
   }
 
   return (
-    <div style={styles.container}>
-      <h3 style={styles.titulo}>Mapa do Labirinto ({size}x{size})</h3>
+    <div className="data-panel" style={{ padding: '1rem' }}>
+      <h3 style={{ margin: '0 0 0.5rem', color: 'var(--header-bg)' }}>Mapa do Labirinto ({size}x{size})</h3>
       {trajeto.length === 0 && (
-        <p style={styles.aviso}>Aguardando dados de telemetria do ESP32…</p>
+        <p style={{ fontSize: '14px', color: 'var(--text-muted)', marginBottom: '1rem' }}>
+          Aguardando dados de telemetria...
+        </p>
       )}
 
       <div
@@ -63,40 +65,34 @@ function ItemLegenda({ cor, texto }) {
 }
 
 const styles = {
-  container: {
-    width: '100%',
-    padding: '1rem',
-    border: '1px solid #ddd',
-    borderRadius: '8px',
-    backgroundColor: '#fafafa',
-  },
-  titulo: { margin: '0 0 0.25rem', color: '#444' },
-  aviso: { fontSize: '14px', color: '#999', marginTop: 0 },
   grid: {
     display: 'grid',
     gap: '2px',
-    width: 'min(360px, 100%)',
+    width: '100%',
+    maxWidth: '400px',
     aspectRatio: '1 / 1',
-    margin: '0.5rem 0',
-    backgroundColor: '#999',
-    border: '2px solid #999',
+    margin: '0 auto 1rem',
+    backgroundColor: 'var(--border)',
+    border: '2px solid var(--border)',
+    borderRadius: '4px',
+    overflow: 'hidden'
   },
   cell: {
-    border: '1px solid #e0e0e0',
+    backgroundColor: 'white',
   },
   legenda: {
     display: 'flex',
     flexWrap: 'wrap',
     gap: '12px',
-    fontSize: '13px',
-    color: '#555',
+    fontSize: '0.85rem',
+    color: 'var(--text-muted)',
+    justifyContent: 'center'
   },
-  legendaItem: { display: 'inline-flex', alignItems: 'center', gap: '4px' },
+  legendaItem: { display: 'inline-flex', alignItems: 'center', gap: '6px' },
   legendaCor: {
-    width: '14px',
-    height: '14px',
-    borderRadius: '3px',
-    border: '1px solid #ccc',
+    width: '12px',
+    height: '12px',
+    borderRadius: '2px',
     display: 'inline-block',
   },
 };

--- a/src/frontend/src/components/__tests__/Layout.test.jsx
+++ b/src/frontend/src/components/__tests__/Layout.test.jsx
@@ -34,8 +34,8 @@ describe('Layout', () => {
     const linkTelemetria = screen.getByText('Telemetria ao Vivo')
     const linkHistorico = screen.getByText('Histórico')
 
-    expect(linkTelemetria).toHaveStyle('color: #61dafb')
-    expect(linkHistorico).toHaveStyle('color: #ccc')
+    expect(linkTelemetria).toHaveClass('active')
+    expect(linkHistorico).not.toHaveClass('active')
   })
 
   it('link Historico esta ativo na rota /historico', () => {
@@ -43,8 +43,8 @@ describe('Layout', () => {
     const linkTelemetria = screen.getByText('Telemetria ao Vivo')
     const linkHistorico = screen.getByText('Histórico')
 
-    expect(linkHistorico).toHaveStyle('color: #61dafb')
-    expect(linkTelemetria).toHaveStyle('color: #ccc')
+    expect(linkHistorico).toHaveClass('active')
+    expect(linkTelemetria).not.toHaveClass('active')
   })
 
   it('navega de Telemetria para Historico e volta', async () => {

--- a/src/frontend/src/components/__tests__/MazeMap.test.jsx
+++ b/src/frontend/src/components/__tests__/MazeMap.test.jsx
@@ -19,12 +19,6 @@ describe('MazeMap', () => {
     expect(screen.getByRole('grid').children).toHaveLength(64)
   })
 
-  it('renderiza 256 celulas para grid 16x16', () => {
-    render(<MazeMap size={16} />)
-    expect(screen.getByText('Mapa do Labirinto (16x16)')).toBeInTheDocument()
-    expect(screen.getByRole('grid').children).toHaveLength(256)
-  })
-
   it('grid tem colunas corretas para o tamanho informado', () => {
     render(<MazeMap size={8} />)
     expect(screen.getByRole('grid')).toHaveStyle('grid-template-columns: repeat(8, 1fr)')

--- a/src/frontend/src/hooks/useHistory.js
+++ b/src/frontend/src/hooks/useHistory.js
@@ -7,7 +7,7 @@ const API_URL =
   `http://${typeof window !== 'undefined' ? window.location.hostname : 'localhost'}:8000`;
 
 // Busca o histórico de corridas no endpoint GET /corridas.
-// `tamanho` pode ser '4x4', '8x8', '16x16' ou 'todos' (sem filtro).
+// `tamanho` pode ser '4x4', '8x8' ou 'todos' (sem filtro).
 export default function useHistory(tamanho) {
   const [corridas, setCorridas] = useState([]);
   const [carregando, setCarregando] = useState(true);

--- a/src/frontend/src/index.css
+++ b/src/frontend/src/index.css
@@ -1,0 +1,206 @@
+:root {
+  --bg-main: #f1f5f9;
+  --bg-panel: #ffffff;
+  --header-bg: #0f172a;
+  --text-main: #1e293b;
+  --text-muted: #64748b;
+  --border: #e2e8f0;
+  --primary: #2563eb;
+  --primary-hover: #1d4ed8;
+  
+  --success: #10b981;
+  --danger: #ef4444;
+  --warning: #f59e0b;
+  --neutral: #94a3b8;
+
+  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+  --radius: 8px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-sans);
+  background-color: var(--bg-main);
+  color: var(--text-main);
+  line-height: 1.5;
+}
+
+h1, h2, h3 {
+  color: var(--header-bg);
+  margin-bottom: 1rem;
+}
+
+button, select {
+  font-family: inherit;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background-color: var(--bg-panel);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+button:hover:not(:disabled) {
+  background-color: var(--bg-main);
+  border-color: var(--primary);
+}
+
+button:disabled, select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.layout-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background-color: var(--header-bg);
+  color: white;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.layout-header h2 {
+  color: white;
+  margin: 0;
+}
+
+.nav-links {
+  display: flex;
+  gap: 1.5rem;
+}
+
+.nav-link {
+  color: #cbd5e1;
+  text-decoration: none;
+  font-weight: 500;
+  padding-bottom: 0.25rem;
+  transition: color 0.2s;
+}
+
+.nav-link:hover { color: white; }
+
+.nav-link.active {
+  color: #38bdf8;
+  border-bottom: 2px solid #38bdf8;
+}
+
+.main-content {
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.telemetry-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+
+.status-pill {
+  color: white;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  margin-top: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .dashboard-grid {
+    grid-template-columns: 300px 1fr;
+  }
+}
+
+.data-panel {
+  background-color: var(--bg-panel);
+  padding: 1.5rem;
+  border-radius: var(--radius);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  border: 1px solid var(--border);
+}
+
+.stat-box {
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+}
+
+.stat-box:last-child { border-bottom: none; }
+
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.table-responsive {
+  width: 100%;
+  overflow-x: auto;
+  background: var(--bg-panel);
+  border-radius: var(--radius);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  border: 1px solid var(--border);
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 600px;
+}
+
+.history-table th {
+  background-color: var(--bg-main);
+  color: var(--text-muted);
+  font-weight: 600;
+  text-align: left;
+  padding: 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.history-table td {
+  padding: 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.feedback-container {
+  text-align: center;
+  padding: 3rem 1rem;
+  border-radius: var(--radius);
+  background: var(--bg-panel);
+  border: 1px dashed var(--border);
+}
+
+.spinner {
+  display: inline-block;
+  width: 30px;
+  height: 30px;
+  border: 3px solid rgba(0,0,0,0.1);
+  border-radius: 50%;
+  border-top-color: var(--primary);
+  animation: spin 1s ease-in-out infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/src/frontend/src/pages/History.jsx
+++ b/src/frontend/src/pages/History.jsx
@@ -29,8 +29,7 @@ export default function History() {
     <div>
       <h1>Histórico de Corridas</h1>
 
-      {/* Filtro */}
-      <div style={{ marginBottom: '1rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+      <div className="filter-bar">
         <label htmlFor="filtro-tamanho">Filtrar por tamanho: </label>
         <select
           id="filtro-tamanho"
@@ -44,81 +43,74 @@ export default function History() {
             </option>
           ))}
         </select>
-        <button onClick={recarregar} disabled={carregando} title="Atualizar">
-          {carregando ? '⏳' : '🔄'}
+        <button 
+          onClick={recarregar} 
+          disabled={carregando} 
+          title="Atualizar"
+          aria-label="Atualizar histórico"
+        >
+          🔄
         </button>
       </div>
 
-      {/* Estado: erro */}
-      {erro && (
-        <div style={{ textAlign: 'center', padding: '2rem', color: '#f87171' }}>
-          <p>⚠️ {erro}</p>
-          <button onClick={recarregar}>Tentar novamente</button>
-        </div>
-      )}
+      {/* Feedbacks Visuais */}
+      <div aria-live="polite">
+        {erro && (
+          <div className="feedback-container" style={{ color: 'var(--danger)' }}>
+            <p style={{ marginBottom: '1rem', fontWeight: 'bold' }}>⚠️ {erro}</p>
+            <button onClick={recarregar}>Tentar novamente</button>
+          </div>
+        )}
 
-      {/* Estado: carregando */}
-      {carregando && !erro && (
-        <p style={{ textAlign: 'center', padding: '1rem' }}>Carregando corridas...</p>
-      )}
+        {carregando && !erro && (
+          <div className="feedback-container">
+            <div className="spinner"></div>
+            <p style={{ marginTop: '1rem', color: 'var(--text-muted)' }}>Carregando corridas...</p>
+          </div>
+        )}
 
-      {/* Estado: vazio */}
-      {!carregando && !erro && corridas.length === 0 && (
-        <p style={{ textAlign: 'center', padding: '2rem', color: '#94a3b8' }}>
-          🏁{' '}
-          {filtro === 'todos'
-            ? 'Nenhuma corrida registrada ainda.'
-            : `Nenhuma corrida encontrada para labirintos ${filtro}.`}
-        </p>
-      )}
+        {!carregando && !erro && corridas.length === 0 && (
+          <div className="feedback-container">
+            <p style={{ fontSize: '2rem', margin: 0 }}>🏁</p>
+            <p style={{ color: 'var(--text-muted)', marginTop: '0.5rem' }}>
+              {filtro === 'todos'
+                ? 'Nenhuma corrida registrada ainda.'
+                : `Nenhuma corrida encontrada para labirintos ${filtro}.`}
+            </p>
+          </div>
+        )}
 
-      {/* Estado: dados */}
-      {!carregando && !erro && corridas.length > 0 && (
-        <>
-          <table style={styles.table}>
-            <thead>
-              <tr style={styles.headerRow}>
-                <th>ID da Corrida</th>
-                <th>Tamanho</th>
-                <th>Duração</th>
-                <th>Resultado</th>
-              </tr>
-            </thead>
-            <tbody>
-              {corridas.map((corrida, idx) => (
-                <tr key={corrida.id ?? idx}>
-                  <td style={styles.td}>{corrida.id ?? '—'}</td>
-                  <td style={styles.td}>{corrida.tamanho ?? '—'}</td>
-                  <td style={styles.td}>{formatarTempo(corrida.duracao)}</td>
-                  <td style={styles.td}>{formatarResultado(corrida.resultado)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          <p style={{ marginTop: '0.5rem', fontSize: '0.8rem', color: '#64748b', textAlign: 'right' }}>
-            {corridas.length} corrida{corridas.length !== 1 ? 's' : ''} encontrada
-            {corridas.length !== 1 ? 's' : ''}
-            {filtro !== 'todos' ? ` para ${filtro}` : ''}.
-          </p>
-        </>
-      )}
+        {!carregando && !erro && corridas.length > 0 && (
+          <>
+            <div className="table-responsive">
+              <table className="history-table">
+                <thead>
+                  <tr>
+                    <th>ID da Corrida</th>
+                    <th>Tamanho</th>
+                    <th>Duração</th>
+                    <th>Resultado</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {corridas.map((corrida, idx) => (
+                    <tr key={corrida.id ?? idx}>
+                      <td>{corrida.id ?? '—'}</td>
+                      <td>{corrida.tamanho ?? '—'}</td>
+                      <td>{formatarTempo(corrida.duracao)}</td>
+                      <td>{formatarResultado(corrida.resultado)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p style={{ marginTop: '1rem', fontSize: '0.85rem', color: 'var(--text-muted)', textAlign: 'right' }}>
+              {corridas.length} corrida{corridas.length !== 1 ? 's' : ''} encontrada{corridas.length !== 1 ? 's' : ''}
+              {filtro !== 'todos' ? ` para ${filtro}` : ''}.
+            </p>
+          </>
+        )}
+      </div>
     </div>
   );
 }
-
-const styles = {
-  table: {
-    width: '100%',
-    borderCollapse: 'collapse',
-    marginTop: '1rem',
-  },
-  headerRow: {
-    backgroundColor: '#282c34',
-    color: 'white',
-    textAlign: 'left',
-  },
-  td: {
-    padding: '0.7rem 1rem',
-    borderBottom: '1px solid #2d3748',
-  },
-};

--- a/src/frontend/src/pages/History.jsx
+++ b/src/frontend/src/pages/History.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import useHistory from '../hooks/useHistory';
 
-const TAMANHOS = ['todos', '4x4', '8x8', '16x16'];
+const TAMANHOS = ['todos', '4x4', '8x8'];
 
 function formatarTempo(segundos) {
   if (segundos == null || isNaN(segundos)) return '—';

--- a/src/frontend/src/pages/Telemetry.jsx
+++ b/src/frontend/src/pages/Telemetry.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import MazeMap from '../components/MazeMap';
 import useTelemetry, { STATUS } from '../hooks/useTelemetry';
 
-const TAMANHOS = [4, 8, 16];
+const TAMANHOS = [4, 8];
 
 const STATUS_INFO = {
   [STATUS.conectando]: { texto: 'Conectando…', cor: 'var(--warning)' },

--- a/src/frontend/src/pages/Telemetry.jsx
+++ b/src/frontend/src/pages/Telemetry.jsx
@@ -5,10 +5,10 @@ import useTelemetry, { STATUS } from '../hooks/useTelemetry';
 const TAMANHOS = [4, 8, 16];
 
 const STATUS_INFO = {
-  [STATUS.conectando]: { texto: 'Conectando…', cor: '#b58900' },
-  [STATUS.conectado]: { texto: 'Conectado', cor: '#2e7d32' },
-  [STATUS.desconectado]: { texto: 'Desconectado', cor: '#c62828' },
-  [STATUS.indisponivel]: { texto: 'WebSocket indisponível', cor: '#888' },
+  [STATUS.conectando]: { texto: 'Conectando…', cor: 'var(--warning)' },
+  [STATUS.conectado]: { texto: 'Conectado', cor: 'var(--success)' },
+  [STATUS.desconectado]: { texto: 'Desconectado', cor: 'var(--danger)' },
+  [STATUS.indisponivel]: { texto: 'WebSocket indisponível', cor: 'var(--neutral)' },
 };
 
 export default function Telemetry() {
@@ -18,14 +18,18 @@ export default function Telemetry() {
 
   return (
     <div>
-      <div style={styles.titleRow}>
-        <h1>Painel de Controle</h1>
-        <span style={{ ...styles.statusPill, backgroundColor: statusInfo.cor }}>
-          ● {statusInfo.texto}
+      <div className="telemetry-header">
+        <h1 style={{ margin: 0 }}>Painel de Controle</h1>
+        <span 
+          className="status-pill" 
+          style={{ backgroundColor: statusInfo.cor }}
+          aria-live="polite"
+        >
+          <span aria-hidden="true">●</span> {statusInfo.texto}
         </span>
       </div>
 
-      <div style={styles.controls}>
+      <div className="filter-bar">
         <label htmlFor="tamanho-labirinto">Tamanho do labirinto: </label>
         <select
           id="tamanho-labirinto"
@@ -40,78 +44,37 @@ export default function Telemetry() {
         </select>
       </div>
 
-      <div style={styles.dashboard}>
-        {/* Painel de métricas */}
-        <div style={styles.dataPanel}>
+      <div className="dashboard-grid">
+        <div className="data-panel">
           <h3>Status da Corrida</h3>
-          <div style={styles.statBox}>
-            <strong>Velocidade Média:</strong>{' '}
-            {t.velocidadeMedia != null ? `${t.velocidadeMedia.toFixed(2)} m/s` : '-- m/s'}
+          <div className="stat-box">
+            <strong>Velocidade Média:</strong>
+            <span>{t.velocidadeMedia != null ? `${t.velocidadeMedia.toFixed(2)} m/s` : '-- m/s'}</span>
           </div>
-          <div style={styles.statBox}>
-            <strong>Tempo:</strong> {t.tempo}
+          <div className="stat-box">
+            <strong>Tempo:</strong> 
+            <span>{t.tempo}</span>
           </div>
-          <div style={styles.statBox}>
-            <strong>Bateria:</strong> {t.bateria != null ? `${Math.round(t.bateria)}%` : '--%'} 🔋
+          <div className="stat-box">
+            <strong>Bateria:</strong>
+            <span>{t.bateria != null ? `${Math.round(t.bateria)}%` : '--%'} 🔋</span>
           </div>
-          <div style={styles.statBox}>
-            <strong>Desafio Cumprido:</strong>{' '}
-            <span style={{ color: t.desafioCumprido ? '#2e7d32' : '#c62828', fontWeight: 'bold' }}>
+          <div className="stat-box">
+            <strong>Desafio Cumprido:</strong>
+            <span style={{ color: t.desafioCumprido ? 'var(--success)' : 'var(--danger)', fontWeight: 'bold' }}>
               {t.desafioCumprido ? 'Sim' : 'Não'}
             </span>
           </div>
-          <div style={styles.statBox}>
-            <strong>Posição:</strong>{' '}
-            {t.posicaoAtual ? `(${t.posicaoAtual.x}, ${t.posicaoAtual.y})` : '--'}
+          <div className="stat-box">
+            <strong>Posição:</strong>
+            <span>{t.posicaoAtual ? `(${t.posicaoAtual.x}, ${t.posicaoAtual.y})` : '--'}</span>
           </div>
         </div>
 
-        {/* Mapa do labirinto com o trajeto em tempo real */}
-        <div style={styles.mapPanel}>
+        <div className="map-panel">
           <MazeMap size={size} trajeto={t.trajeto} posicaoAtual={t.posicaoAtual} />
         </div>
       </div>
     </div>
   );
 }
-
-const styles = {
-  titleRow: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '1rem',
-    flexWrap: 'wrap',
-  },
-  statusPill: {
-    color: 'white',
-    fontSize: '13px',
-    fontWeight: 'bold',
-    padding: '4px 10px',
-    borderRadius: '12px',
-  },
-  controls: {
-    marginTop: '0.5rem',
-  },
-  dashboard: {
-    display: 'flex',
-    gap: '2rem',
-    marginTop: '1rem',
-    flexWrap: 'wrap',
-  },
-  dataPanel: {
-    flex: 1,
-    minWidth: '240px',
-    padding: '1rem',
-    backgroundColor: '#f4f4f4',
-    borderRadius: '8px',
-  },
-  mapPanel: {
-    flex: 2,
-    minWidth: '280px',
-  },
-  statBox: {
-    padding: '10px',
-    borderBottom: '1px solid #ddd',
-    fontSize: '16px',
-  },
-};

--- a/src/frontend/src/pages/Telemetry.t10.test.jsx
+++ b/src/frontend/src/pages/Telemetry.t10.test.jsx
@@ -68,7 +68,7 @@ function telemetria(overrides = {}) {
   }
 }
 
-const COR_POSICAO = '#1565c0'
+const COR_POSICAO = '#2563eb'
 
 // ===========================================================================
 // 1. Renderização inicial

--- a/src/frontend/src/pages/Telemetry.t10.test.jsx
+++ b/src/frontend/src/pages/Telemetry.t10.test.jsx
@@ -204,10 +204,10 @@ describe('Telemetry (T10) — grid do labirinto', () => {
     render(<Telemetry />)
 
     const seletor = screen.getByLabelText(/Tamanho do labirinto/i)
-    fireEvent.change(seletor, { target: { value: '16' } })
+    fireEvent.change(seletor, { target: { value: '8' } })
 
-    expect(screen.getByRole('heading', { name: /Mapa do Labirinto \(16x16\)/ })).toBeInTheDocument()
-    expect(screen.getByRole('grid').children).toHaveLength(256)
+    expect(screen.getByRole('heading', { name: /Mapa do Labirinto \(8x8\)/ })).toBeInTheDocument()
+    expect(screen.getByRole('grid').children).toHaveLength(64)
   })
 
   it('recalcula "Desafio Cumprido" conforme o tamanho selecionado', () => {
@@ -219,8 +219,8 @@ describe('Telemetry (T10) — grid do labirinto', () => {
     ws.emitTelemetria(telemetria({ posicao_x: 1, posicao_y: 1 }))
     expect(screen.getByText('Sim')).toBeInTheDocument()
 
-    // No 16x16 a mesma posição não é o centro -> desafio deixa de estar cumprido.
-    fireEvent.change(screen.getByLabelText(/Tamanho do labirinto/i), { target: { value: '16' } })
+    // No 8x8 a mesma posição não é o centro -> desafio deixa de estar cumprido.
+    fireEvent.change(screen.getByLabelText(/Tamanho do labirinto/i), { target: { value: '8' } })
     expect(screen.getByText('Não')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Resumo

Polimento visual das telas de Telemetria e Histórico, conforme a Tarefa 5.4. Introduz um design system em CSS e refatora os componentes para consumi-lo. Inclui tambem o ajuste de escopo que remove o labirinto 16x16 da UI apos a revisao de cronograma.

Closes #25

## O que foi feito (refinamento de UI)

Cobre os quatro criterios da issue:

- **Paleta de cores e tipografia:** novo design system em `index.css` com variaveis CSS (cores, raio, fonte Inter) e estilos base de botoes, cabecalho e paineis.
- **Responsividade (desktop e tablet):** layout do painel em CSS Grid com breakpoint em 768px e tabela do historico com rolagem horizontal (`table-responsive`).
- **Feedback visual:** spinner de carregamento, `status-pill` de conexao, estado de erro com botao "Tentar novamente" e estado vazio dedicado.
- **Acessibilidade basica:** `aria-label` nos controles, regioes dinamicas com `aria-live="polite"` e `aria-hidden` nos icones decorativos.

Arquivos: `index.css`, `Layout.jsx`, `MazeMap.jsx`, `History.jsx`, `Telemetry.jsx`.

## Ajuste de escopo: remocao do 16x16

Apos a revisao de cronograma dos professores (19/06), os cenarios de avaliacao passaram a ser 4x4, 4x4 e 8x8; o 16x16 saiu do escopo (ver #22). Removida a opcao 16x16 do filtro do Historico e do seletor de tamanho da Telemetria. O componente `MazeMap` segue generico (aceita qualquer N).

## Ajuste de testes

A migracao de estilos inline para classes CSS quebrava asserções acopladas a cores fixas; foram atualizadas para verificar comportamento. Os testes de tamanho de labirinto passam a usar 8x8 no lugar do 16x16.

- `Layout.test.jsx`: checa a classe `active` do link de navegacao.
- `Telemetry.t10.test.jsx`: `COR_POSICAO` na nova cor primaria (#2563eb); troca de tamanho e "Desafio Cumprido" usam 8x8.
- `MazeMap.test.jsx`: removido o caso 16x16 (4x4 e 8x8 cobrem a renderizacao generica).

## Validacao

Suite Vitest completa: **36 testes, 36 passando**.